### PR TITLE
Add minimal support for mock crust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ name = "simulate_browser"
 
 [features]
 use-mock-routing = []
+use-mock-crust = ["routing/use-mock-crust"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@
 #![cfg_attr(feature="clippy", deny(clippy, clippy_pedantic))]
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
+#![cfg(not(feature = "use-mock-crust"))]
+
 #[macro_use]
 extern crate log;
 extern crate time;


### PR DESCRIPTION
Adds minimal support for `use-mock-crust` feature. Enabling it currently disables the whole library, but it is necessary to make mock crust work in vault.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/230)
<!-- Reviewable:end -->