### PR TITLE
fix/dependency: revert to previous regex from crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ version = "~0.0.63"
 
 [dev-dependencies]
 docopt = "~0.6.80"
-regex = "~0.1.66"
+regex = "~0.1.65"
 
 [[example]]
 bench = false


### PR DESCRIPTION
The latest regex version of 0.1.66 has been yanked from crates.io: https://crates.io/crates/regex/versions. So the build fails. This commit reverts it to the next latest regex in the crates (0.1.65)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/245)
<!-- Reviewable:end -->