### PR TITLE
feat/account_info: add support for providing client account information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.15.0"
 
 [dependencies]
 bincode = "~0.5.6"
-clippy = {version = "~0.0.69", optional = true}
+clippy = {version = "~0.0.74", optional = true}
 libc = "~0.2.11"
 log = "~0.3.6"
 lru_time_cache = "~0.4.0"

--- a/src/core/client/message_queue.rs
+++ b/src/core/client/message_queue.rs
@@ -129,6 +129,26 @@ fn handle_response(response: Response, mut queue_guard: MutexGuard<MessageQueue>
                 let _ = response_observer.send(ResponseEvent::MutationResp(err));
             }
         }
+        Response::GetAccountInfoSuccess { id, data_stored, space_available } => {
+            if let Some(response_observer) = queue_guard.response_observers.remove(&id) {
+                let _ = response_observer.send(
+                    ResponseEvent::GetAccountInfoResp(Ok((data_stored, space_available))));
+            }
+        }
+        Response::GetAccountInfoFailure { id, external_error_indicator } => {
+            if let Some(response_observer) = queue_guard.response_observers.remove(&id) {
+                let reason: GetError = match deserialise(&external_error_indicator) {
+                    Ok(err) => err,
+                    Err(err) => {
+                        let err_msg = format!("Couldn't obtain GET Failure reason: {:?}", err);
+                        warn!("{}", err_msg);
+                        GetError::NetworkOther(err_msg)
+                    }
+                };
+                let err = Err(CoreError::GetAccountInfoFailure { reason: reason });
+                let _ = response_observer.send(ResponseEvent::GetAccountInfoResp(err));
+            }
+        }
     }
 }
 

--- a/src/core/client/response_getter.rs
+++ b/src/core/client/response_getter.rs
@@ -22,9 +22,12 @@ use std::sync::mpsc::{Sender, Receiver};
 use core::client::message_queue::MessageQueue;
 use core::translated_events::ResponseEvent;
 
-/// GetResponseGetter is a lazy evaluated response getter for GET Requests. It will fetch either
-/// from local cache or wait for the MessageQueue to notify it of the incoming response from the
-/// network
+// TODO - consider using template specialisation (if it becomes available) for these three structs
+//        which all do similar things.
+
+/// `GetResponseGetter` is a lazy evaluated response getter for GET Requests. It will fetch either
+/// from local cache or wait for the `MessageQueue` to notify it of the incoming response from the
+/// network.
 pub struct GetResponseGetter {
     data_channel: Option<(Sender<ResponseEvent>, Receiver<ResponseEvent>)>,
     message_queue: Arc<Mutex<MessageQueue>>,
@@ -33,7 +36,7 @@ pub struct GetResponseGetter {
 }
 
 impl GetResponseGetter {
-    /// Create a new instance of GetResponseGetter
+    /// Create a new instance of `GetResponseGetter`
     pub fn new(data_channel: Option<(Sender<ResponseEvent>, Receiver<ResponseEvent>)>,
                message_queue: Arc<Mutex<MessageQueue>>,
                requested_id: DataIdentifier)
@@ -74,6 +77,40 @@ impl GetResponseGetter {
     /// on `get()` fire `sender.send(ResponseEvent::Terminated)` to gracefully exit the receiver.
     pub fn get_sender(&self) -> Option<&Sender<ResponseEvent>> {
         self.data_channel.as_ref().and_then(|&(ref sender, _)| Some(sender))
+    }
+}
+
+/// `GetAccountInfoResponseGetter` is a lazy evaluated response getter for `GetAccountInfo`
+/// Requests. It will wait for the `MessageQueue` to notify it of the incoming response from the
+/// network.
+pub struct GetAccountInfoResponseGetter {
+    data_channel: (Sender<ResponseEvent>, Receiver<ResponseEvent>),
+}
+
+impl GetAccountInfoResponseGetter {
+    /// Create a new instance of `GetAccountInfoResponseGetter`
+    pub fn new(data_channel: (Sender<ResponseEvent>, Receiver<ResponseEvent>))
+               -> GetAccountInfoResponseGetter {
+        GetAccountInfoResponseGetter { data_channel: data_channel }
+    }
+
+    /// Get result from the network as informed by MessageQueue. This is blocking. Tuple fields of
+    /// result are `(data_stored, space_available)`.
+    pub fn get(&self) -> Result<(u64, u64), CoreError> {
+        let (_, ref data_receiver) = self.data_channel;
+        let res = data_receiver.recv();
+        match try!(res) {
+            ResponseEvent::GetAccountInfoResp(result) => result,
+            ResponseEvent::Terminated => Err(CoreError::OperationAborted),
+            _ => Err(CoreError::ReceivedUnexpectedData),
+        }
+    }
+
+    /// Extract associated sender. This will help cancel the blocking wait at will if so desired.
+    /// All that is needed is to extract the sender before doing a `get()` and then while blocking
+    /// on `get()` fire `sender.send(ResponseEvent::Terminated)` to gracefully exit the receiver.
+    pub fn get_sender(&self) -> &Sender<ResponseEvent> {
+        &self.data_channel.0
     }
 }
 

--- a/src/core/translated_events.rs
+++ b/src/core/translated_events.rs
@@ -26,6 +26,8 @@ pub const NETWORK_EVENT_START_RANGE: i32 = 0;
 pub enum ResponseEvent {
     /// Response to a previous GET request
     GetResp(Result<Data, CoreError>),
+    /// Response to a previous GetAccountInfo request
+    GetAccountInfoResp(Result<(u64, u64), CoreError>),
     /// Response to a previous Mutating (PUT/POST/DELETE) request
     MutationResp(Result<(), CoreError>),
     /// Graceful Exit Condition

--- a/src/nfs/metadata/directory_metadata.rs
+++ b/src/nfs/metadata/directory_metadata.rs
@@ -183,7 +183,7 @@ mod test {
     use nfs::AccessLevel;
 
     #[test]
-    fn serialise_directorty_metadata_without_parent_directory() {
+    fn serialise_directory_metadata_without_parent_directory() {
         let obj_before = unwrap_result!(DirectoryMetadata::new("hello.txt".to_string(),
                                                                99u64,
                                                                true,
@@ -196,7 +196,7 @@ mod test {
     }
 
     #[test]
-    fn serialise_directorty_metadata_with_parent_directory() {
+    fn serialise_directory_metadata_with_parent_directory() {
         let id: XorName = rand::random();
         let parent_directory = DirectoryKey::new(id, 100u64, false, AccessLevel::Private);
         let obj_before = unwrap_result!(DirectoryMetadata::new("hello.txt".to_string(),


### PR DESCRIPTION
This implements the client-side portion of the new `GetAccountInfo` Client request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/259)
<!-- Reviewable:end -->
