### PR TITLE
fix/dns: enable registered client to fetch public dns file

### DIFF
--- a/src/dns/dns_operations/mod.rs
+++ b/src/dns/dns_operations/mod.rs
@@ -204,7 +204,7 @@ impl DnsOperations {
             Err(error) => return Err(error),
         };
         let (_, dns_record) =
-            try!(self.get_housing_structured_data_and_dns_record(long_name, data_decryption_keys));        
+            try!(self.get_housing_structured_data_and_dns_record(long_name, data_decryption_keys));
         dns_record.services
             .get(service_name)
             .map(|v| v.clone())

--- a/src/dns/dns_operations/mod.rs
+++ b/src/dns/dns_operations/mod.rs
@@ -200,11 +200,11 @@ impl DnsOperations {
             Err(DnsError::CoreError(CoreError::OperationForbiddenForClient)) => (),
             Err(DnsError::NfsError(NfsError::CoreError(
                 CoreError::OperationForbiddenForClient))) => (),
+            Err(DnsError::DnsRecordNotFound) => (),
             Err(error) => return Err(error),
         };
-
         let (_, dns_record) =
-            try!(self.get_housing_structured_data_and_dns_record(long_name, data_decryption_keys));
+            try!(self.get_housing_structured_data_and_dns_record(long_name, data_decryption_keys));        
         dns_record.services
             .get(service_name)
             .map(|v| v.clone())

--- a/src/ffi/dns/get_file.rs
+++ b/src/ffi/dns/get_file.rs
@@ -61,3 +61,106 @@ impl Action for GetFile {
         Ok(Some(try!(json::encode(&response))))
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use core::utility;
+    use sodiumoxide::crypto::box_;
+    use dns::dns_operations::DnsOperations;
+    use ffi::{Action, test_utils, ParameterPacket, errors};
+    use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+    use nfs::metadata::directory_key::DirectoryKey;
+    use nfs::helper::file_helper::FileHelper;
+    use nfs::helper::directory_helper::DirectoryHelper;
+
+    fn create_public_file(params: &ParameterPacket,
+                          file_name: String,
+                          file_content: Vec<u8>)
+                          -> Result<DirectoryKey, errors::FfiError> {
+        let directory_helper = DirectoryHelper::new(params.clone().client);
+        let mut file_directory =
+            try!(directory_helper.get(&try!(params.clone()
+                                                  .app_root_dir_key
+                                                  .ok_or(errors::FfiError::from("Application \
+                                                                                 directory \
+                                                                                 key is not \
+                                                                                 present")))));
+
+        let (file_directory, _) = try!(directory_helper.create(String::from("public-dir"),
+                                                               UNVERSIONED_DIRECTORY_LISTING_TAG,
+                                                               vec![0u8; 0],
+                                                               false,
+                                                               AccessLevel::Public,
+                                                               Some(&mut file_directory)));
+        let mut file_helper = FileHelper::new(params.clone().client);
+        let bin_metadata = vec![0u8; 0];
+
+        let key = file_directory.get_key().clone();
+        let mut writer = try!(file_helper.create(file_name, bin_metadata, file_directory));
+        try!(writer.write(&file_content[..], 0));
+        let _ = try!(writer.close());
+
+        Ok(key)
+    }
+
+    fn register_service(params: &ParameterPacket,
+                        service_name: String,
+                        public_name: String,
+                        directory_key: DirectoryKey)
+                        -> Result<(), errors::FfiError> {
+        let (msg_public_key, msg_secret_key) = box_::gen_keypair();
+        let services = vec![(service_name.clone(), (directory_key.clone()))];
+        let public_signing_key = try!(unwrap_result!(params.client.lock())
+                                          .get_public_signing_key())
+                                     .clone();
+        let secret_signing_key = try!(unwrap_result!(params.client.lock())
+                                          .get_secret_signing_key())
+                                     .clone();
+        let dns_operation = try!(DnsOperations::new(params.client
+                                                          .clone()));
+        try!(dns_operation.register_dns(public_name.clone(),
+                                        &msg_public_key,
+                                        &msg_secret_key,
+                                        &services,
+                                        vec![public_signing_key],
+                                        &secret_signing_key,
+                                        None));
+        Ok(())
+    }
+
+    #[test]
+    fn get_public_file_using_registerd_client() {
+        let parameter_packet = unwrap_result!(test_utils::get_parameter_packet(false));
+        let file_name = String::from("index.html");
+        let file_content = String::from("<html><title>Home</title></html>");
+        let public_directory_key = unwrap_result!(create_public_file(&parameter_packet,
+                                                                     file_name.clone(),
+                                                                     file_content.into_bytes()));
+        let service_name = String::from("www");
+        let public_name = unwrap_result!(utility::generate_random_string(10));
+        unwrap_result!(register_service(&parameter_packet,
+                                        service_name.clone(),
+                                        public_name.clone(),
+                                        public_directory_key));
+
+        // Fecth the file using the same client
+        let mut request = GetFile {
+            long_name: public_name,
+            service_name: service_name,
+            offset: 0i64,
+            length: 0i64,
+            file_path: file_name,
+            include_metadata: false,
+        };
+        assert!(request.execute(parameter_packet).is_ok());
+        // Fetch the file using a new client
+        let new_parameter_packet = unwrap_result!(test_utils::get_parameter_packet(false));
+        assert!(request.execute(new_parameter_packet).is_ok());
+        // Fetch the file using an unregisterd client
+        let unreg_parameter_packet =
+            unwrap_result!(test_utils::get_unregistered_parameter_packet());
+        assert!(request.execute(unreg_parameter_packet).is_ok());
+    }
+}


### PR DESCRIPTION
Previously only registered owner and unregistered client could fetch the public dns file. A registered client could not fetch a public file that had been created by another owner. This fix aims to resolve that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/262)
<!-- Reviewable:end -->
