### PR TITLE
Fix `create_account` comment typo

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -278,7 +278,7 @@ pub extern "C" fn get_safe_drive_key(c_size: *mut int32_t,
 }
 
 /// Discard and clean up the previously allocated client. Use this only if the client is obtained
-/// from one of the client obtainment functions in this crate (`crate_account`, `log_in`,
+/// from one of the client obtainment functions in this crate (`create_account`, `log_in`,
 /// `create_unregistered_client`). Using `client_handle` after a call to this functions is
 /// undefined behaviour.
 #[no_mangle]


### PR DESCRIPTION
Method name in comment `crate_account` doesn't exist, but `create_account` does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/266)
<!-- Reviewable:end -->
