### PR TITLE
feat/put_recover: implement Client::put_recover

### DIFF
--- a/src/core/self_encryption_storage.rs
+++ b/src/core/self_encryption_storage.rs
@@ -68,6 +68,6 @@ impl Storage<SelfEncryptionStorageError> for SelfEncryptionStorage {
     fn put(&mut self, _: Vec<u8>, data: Vec<u8>) -> Result<(), SelfEncryptionStorageError> {
         let immutable_data = ImmutableData::new(data);
         let mut client = self.client.lock().expect("Failed to lock client mutex.");
-        Ok(try!(try!(client.put(Data::Immutable(immutable_data), None)).get()))
+        Ok(try!(client.put_recover(Data::Immutable(immutable_data), None)))
     }
 }

--- a/src/core/structured_data_operations/unversioned.rs
+++ b/src/core/structured_data_operations/unversioned.rs
@@ -90,7 +90,7 @@ pub fn create(client: Arc<Mutex<Client>>,
                     let immutable_data = ImmutableData::new(data_to_store);
                     let name = immutable_data.name();
                     let data = Data::Immutable(immutable_data);
-                    try!(try!(unwrap_result!(client.lock()).put(data, None)).get());
+                    try!(unwrap_result!(client.lock()).put_recover(data, None));
 
                     let data_to_store = try!(get_encoded_data_to_store(
                         DataTypeEncoding::MapName(name), data_encryption_keys));

--- a/src/core/structured_data_operations/versioned.rs
+++ b/src/core/structured_data_operations/versioned.rs
@@ -89,7 +89,7 @@ fn create_impl(client: &mut Client,
                                                         prev_owner_keys.clone())) {
         DataFitResult::DataFits => {
             let data = Data::Immutable(immutable_data);
-            try!(try!(client.put(data, None)).get());
+            try!(client.put_recover(data, None));
 
             Ok(try!(StructuredData::new(tag_type,
                                         identifier,

--- a/src/dns/dns_operations/mod.rs
+++ b/src/dns/dns_operations/mod.rs
@@ -91,9 +91,9 @@ impl DnsOperations {
                                                        vec![],
                                                        private_signing_key,
                                                        data_encryption_keys));
-            match try!(unwrap_result!(self.client.lock())
-                           .put(Data::Structured(struct_data), None))
-                      .get() {
+            match unwrap_result!(self.client.lock())
+                            .put_recover(Data::Structured(struct_data), None)
+            {
                 Ok(()) => (),
                 Err(CoreError::MutationFailure { reason: MutationError::DataExists, .. }) => {
                     return Err(DnsError::DnsNameAlreadyRegistered)

--- a/src/nfs/helper/directory_helper.rs
+++ b/src/nfs/helper/directory_helper.rs
@@ -73,8 +73,7 @@ impl DirectoryHelper {
 
         let structured_data = try!(self.save_directory_listing(&directory));
         debug!("Posting PUT request to network to save structured data for directory ...");
-        try!(try!(unwrap_result!(self.client.lock()).put(Data::Structured(structured_data), None))
-            .get());
+        try!(unwrap_result!(self.client.lock()).put_recover(Data::Structured(structured_data), None));
         if let Some(mut parent_directory) = parent_directory {
             parent_directory.upsert_sub_directory(directory.get_metadata().clone());
             Ok((directory, try!(self.update(parent_directory))))
@@ -363,8 +362,7 @@ impl DirectoryHelper {
         let immutable_data = ImmutableData::new(data);
         let name = immutable_data.name();
         debug!("Posting PUT request to save immutable data to the network ...");
-        try!(try!(unwrap_result!(self.client.lock()).put(Data::Immutable(immutable_data), None))
-            .get());
+        try!(unwrap_result!(self.client.lock()).put_recover(Data::Immutable(immutable_data), None));
         Ok(name)
     }
 


### PR DESCRIPTION
Client::put_recover is a blocking alternative to Client::put that will
attempt to see if the data has already been uploaded if a put fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/267)
<!-- Reviewable:end -->
