### PR TITLE
fix:ffi_api/resolve move directory issue

### DIFF
--- a/src/ffi/dns/get_file_metadata.rs
+++ b/src/ffi/dns/get_file_metadata.rs
@@ -1,0 +1,53 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use rustc_serialize::json;
+use dns::dns_operations::DnsOperations;
+use ffi::{helper, ParameterPacket, ResponseType, Action};
+use ffi::errors::FfiError;
+use nfs::helper::directory_helper::DirectoryHelper;
+
+#[derive(RustcDecodable, Debug)]
+pub struct GetFileMetadata {
+    pub long_name: String,
+    pub service_name: String,
+    pub file_path: String,
+}
+
+impl Action for GetFileMetadata {
+    fn execute(&mut self, params: ParameterPacket) -> ResponseType {
+        let dns_operations = match params.app_root_dir_key {
+            Some(_) => try!(DnsOperations::new(params.client.clone())),
+            None => DnsOperations::new_unregistered(params.client.clone()),
+        };
+        let directory_key = try!(dns_operations.get_service_home_directory_key(&self.long_name,
+                                                                               &self.service_name,
+                                                                               None));
+        let mut tokens = helper::tokenise_path(&self.file_path, false);
+        let file_name = try!(tokens.pop().ok_or(FfiError::InvalidPath));
+        let file_dir = if tokens.len() > 0 {
+            try!(helper::get_final_subdirectory(params.client.clone(),
+                                                &tokens,
+                                                Some(&directory_key)))
+        } else {
+            let dir_helper = DirectoryHelper::new(params.client.clone());
+            try!(dir_helper.get(&directory_key))
+        };
+        let file = try!(file_dir.find_file(&file_name).ok_or(FfiError::InvalidPath));
+        Ok(Some(try!(json::encode(file.get_metadata()))))
+    }
+}

--- a/src/ffi/dns/mod.rs
+++ b/src/ffi/dns/mod.rs
@@ -28,6 +28,7 @@ mod register_dns;
 mod get_services;
 mod get_long_names;
 mod delete_service;
+mod get_file_metadata;
 mod register_public_id;
 mod get_service_directory;
 
@@ -95,6 +96,12 @@ fn get_action<D>(action: String, decoder: &mut D) -> Result<Box<Action>, FfiErro
                                             delete_service::DeleteService::decode(d)
                                         }),
                                         "")))
+        }
+        "get-file-metadata" => {
+             Box::new(try!(parse_result!(decoder.read_struct_field("data", 0, |d| {
+                                             get_file_metadata::GetFileMetadata::decode(d)
+                                         }),
+                                         "")))
         }
         _ => {
             return Err(FfiError::SpecificParseError(format!("Unsupported action {:?} for this \

--- a/src/ffi/nfs/get_file_metadata.rs
+++ b/src/ffi/nfs/get_file_metadata.rs
@@ -1,0 +1,51 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use ffi::errors::FfiError;
+use ffi::{helper, ParameterPacket, ResponseType, Action};
+use rustc_serialize::json;
+
+#[derive(RustcDecodable, Debug)]
+pub struct GetFileMetadata {
+    file_path: String,
+    is_path_shared: bool,
+}
+
+impl Action for GetFileMetadata {
+    fn execute(&mut self, params: ParameterPacket) -> ResponseType {
+
+        if self.is_path_shared && !params.safe_drive_access {
+            return Err(FfiError::PermissionDenied);
+        }
+        let mut tokens = helper::tokenise_path(&self.file_path, false);
+        let file_name = try!(tokens.pop().ok_or(FfiError::InvalidPath));
+        let start_dir_key = if self.is_path_shared {
+            try!(params.safe_drive_dir_key
+                       .ok_or(FfiError::from("Safe Drive directory key is not present")))
+        } else {
+            try!(params.app_root_dir_key
+                       .ok_or(FfiError::from("Application directory key is not present")))
+        };
+        let file_dir = try!(helper::get_final_subdirectory(params.client.clone(),
+                                                           &tokens,
+                                                           Some(&start_dir_key)));
+        let file = try!(file_dir.find_file(&file_name)
+                                .ok_or(FfiError::InvalidPath));
+
+        Ok(Some(try!(json::encode(file.get_metadata()))))
+    }
+}

--- a/src/ffi/nfs/mod.rs
+++ b/src/ffi/nfs/mod.rs
@@ -31,6 +31,7 @@ mod move_dir;
 mod move_file;
 mod modify_dir;
 mod modify_file;
+mod get_file_metadata;
 pub mod directory_response;
 pub mod file_response;
 
@@ -110,7 +111,12 @@ fn get_action<D>(action: String, decoder: &mut D) -> Result<Box<Action>, FfiErro
                                         }),
                                         "")))
         }
-
+        "get-file-metadata" => {
+             Box::new(try!(parse_result!(decoder.read_struct_field("data", 0, |d| {
+                                             get_file_metadata::GetFileMetadata::decode(d)
+                                         }),
+                                         "")))
+        }
         _ => {
             return Err(FfiError::SpecificParseError(format!("Unsupported action {:?} for this \
                                                              endpoint.",

--- a/src/ffi/nfs/move_dir.rs
+++ b/src/ffi/nfs/move_dir.rs
@@ -38,12 +38,12 @@ impl MoveDirectory {
                      -> Result<DirectoryListing, FfiError> {
         let start_dir_key = if shared {
             try!(params.clone()
-                .safe_drive_dir_key
-                .ok_or(FfiError::from("Safe Drive directory key is not present")))
+                       .safe_drive_dir_key
+                       .ok_or(FfiError::from("Safe Drive directory key is not present")))
         } else {
             try!(params.clone()
-                .app_root_dir_key
-                .ok_or(FfiError::from("Application directory key is not present")))
+                       .app_root_dir_key
+                       .ok_or(FfiError::from("Application directory key is not present")))
         };
 
         let tokens = helper::tokenise_path(path, false);
@@ -57,14 +57,20 @@ impl Action for MoveDirectory {
             return Err(FfiError::PermissionDenied);
         }
         let directory_helper = DirectoryHelper::new(params.client.clone());
-        let mut src_dir =
-            try!(self.get_directory(&params, self.is_src_path_shared, &self.src_path));
-        let mut dest_dir =
-            try!(self.get_directory(&params, self.is_dest_path_shared, &self.dest_path));
+        let mut src_dir = try!(self.get_directory(&params,
+                                                  self.is_src_path_shared,
+                                                  &self.src_path));
+        let mut dest_dir = try!(self.get_directory(&params,
+                                                   self.is_dest_path_shared,
+                                                   &self.dest_path));
         if dest_dir.find_sub_directory(src_dir.get_metadata().get_name()).is_some() {
             return Err(FfiError::from(DirectoryAlreadyExistsWithSameName));
         }
-        let org_parent_of_src_dir = src_dir.get_metadata().get_key().clone();
+        let org_parent_of_src_dir = try!(src_dir.get_metadata()
+                                                .get_parent_dir_key()
+                                                .map(|x| x.clone())
+                                                .ok_or(FfiError::from("Parent directory not \
+                                                                       found")));
         if self.retain_source {
             let name = src_dir.get_metadata().get_name().clone();
             let user_metadata = src_dir.get_metadata().get_user_metadata().clone();
@@ -73,42 +79,128 @@ impl Action for MoveDirectory {
             let modified_time = src_dir.get_metadata().get_modified_time().clone();
             let mut dir = try!(DirectoryListing::new(name,
                                                      src_dir.get_metadata()
-                                                         .get_key()
-                                                         .get_type_tag(),
+                                                            .get_key()
+                                                            .get_type_tag(),
                                                      user_metadata,
                                                      src_dir.get_metadata()
-                                                         .get_key()
-                                                         .is_versioned(),
+                                                            .get_key()
+                                                            .is_versioned(),
                                                      access_level,
                                                      src_dir.get_metadata()
-                                                         .get_parent_dir_key()
-                                                         .map(|key| key.clone())));
+                                                            .get_parent_dir_key()
+                                                            .map(|key| key.clone())));
             src_dir.get_files().iter().all(|file| {
                 dir.get_mut_files().push(file.clone());
                 true
             });
             src_dir.get_sub_directories()
-                .iter()
-                .all(|sub_dir| {
-                    dir.get_mut_sub_directories().push(sub_dir.clone());
-                    true
-                });
+                   .iter()
+                   .all(|sub_dir| {
+                       dir.get_mut_sub_directories().push(sub_dir.clone());
+                       true
+                   });
             dir.get_mut_metadata().set_created_time(created_time);
             dir.get_mut_metadata().set_modified_time(modified_time);
             src_dir = dir;
         } else {
             src_dir.get_mut_metadata()
-                .set_parent_dir_key(Some(dest_dir.get_metadata().get_key().clone()));
+                   .set_parent_dir_key(Some(dest_dir.get_metadata().get_key().clone()));
         }
         dest_dir.upsert_sub_directory(src_dir.get_metadata().clone());
         let _ = try!(directory_helper.update(&dest_dir));
-        let _ = try!(directory_helper.update(&src_dir));
         if !self.retain_source {
+            let _ = try!(directory_helper.update(&src_dir));
             let mut parent_of_src_dir = try!(directory_helper.get(&org_parent_of_src_dir));
-            try!(parent_of_src_dir.remove_sub_directory(dest_dir.get_metadata()
-                .get_name()));
+            try!(parent_of_src_dir.remove_sub_directory(src_dir.get_metadata()
+                                                               .get_name()));
             let _ = try!(directory_helper.update(&parent_of_src_dir));
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::MoveDirectory;
+    use ffi::{Action, ParameterPacket, test_utils};
+    use nfs::helper::directory_helper::DirectoryHelper;
+    use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+
+    fn create_directories(parameter_packet: &ParameterPacket) {
+        let dir_helper = DirectoryHelper::new(parameter_packet.client.clone());
+        let app_root_dir_key = unwrap_option!(parameter_packet.clone().app_root_dir_key, "");
+        let mut app_root_dir = unwrap_result!(dir_helper.get(&app_root_dir_key));
+        let _ = unwrap_result!(dir_helper.create(String::from("ParentA"),
+                                                 UNVERSIONED_DIRECTORY_LISTING_TAG,
+                                                 vec![0u8, 0],
+                                                 false,
+                                                 AccessLevel::Private,
+                                                 Some(&mut app_root_dir)));
+        let mut app_root_dir = unwrap_result!(dir_helper.get(&app_root_dir_key));
+        let _ = unwrap_result!(dir_helper.create(String::from("ParentB"),
+                                                 UNVERSIONED_DIRECTORY_LISTING_TAG,
+                                                 vec![0u8, 0],
+                                                 false,
+                                                 AccessLevel::Private,
+                                                 Some(&mut app_root_dir)));
+    }
+
+    #[test]
+    fn move_dir() {
+        let parameter_packet = unwrap_result!(test_utils::get_parameter_packet(false));
+        let dir_helper = DirectoryHelper::new(parameter_packet.client.clone());
+        let app_root_dir_key = unwrap_option!(parameter_packet.clone().app_root_dir_key, "");
+        create_directories(&parameter_packet);
+        let dest_dir_name = String::from("ParentB");
+        let app_root_dir = unwrap_result!(dir_helper.get(&app_root_dir_key));
+        assert_eq!(app_root_dir.get_sub_directories().len(), 2);
+        let dest_dir_key = unwrap_option!(app_root_dir.find_sub_directory(&dest_dir_name), "")
+                               .get_key();
+        let dest_dir = unwrap_result!(dir_helper.get(&dest_dir_key));
+        assert_eq!(dest_dir.get_sub_directories().len(), 0);
+        let mut request = MoveDirectory {
+            src_path: String::from("/ParentA"),
+            is_src_path_shared: false,
+            dest_path: String::from("/ParentB"),
+            is_dest_path_shared: false,
+            retain_source: false,
+        };
+        let _ = unwrap_result!(request.execute(parameter_packet.clone()));
+        let dir_helper = DirectoryHelper::new(parameter_packet.client.clone());
+        let app_root_dir_key = unwrap_option!(parameter_packet.clone().app_root_dir_key, "");
+        let app_root_dir = unwrap_result!(dir_helper.get(&app_root_dir_key));
+        assert_eq!(app_root_dir.get_sub_directories().len(), 1);
+        let dest_dir = unwrap_result!(dir_helper.get(&dest_dir_key));
+        assert_eq!(dest_dir.get_sub_directories().len(), 1);
+    }
+
+
+    #[test]
+    fn copy_dir() {
+        let parameter_packet = unwrap_result!(test_utils::get_parameter_packet(false));
+        let dir_helper = DirectoryHelper::new(parameter_packet.client.clone());
+        let app_root_dir_key = unwrap_option!(parameter_packet.clone().app_root_dir_key, "");
+        create_directories(&parameter_packet);
+        let dest_dir_name = String::from("ParentB");
+        let app_root_dir = unwrap_result!(dir_helper.get(&app_root_dir_key));
+        assert_eq!(app_root_dir.get_sub_directories().len(), 2);
+        let dest_dir_key = unwrap_option!(app_root_dir.find_sub_directory(&dest_dir_name), "")
+                               .get_key();
+        let dest_dir = unwrap_result!(dir_helper.get(&dest_dir_key));
+        assert_eq!(dest_dir.get_sub_directories().len(), 0);
+        let mut request = MoveDirectory {
+            src_path: String::from("/ParentA"),
+            is_src_path_shared: false,
+            dest_path: String::from("/ParentB"),
+            is_dest_path_shared: false,
+            retain_source: true,
+        };
+        let _ = unwrap_result!(request.execute(parameter_packet.clone()));
+        let dir_helper = DirectoryHelper::new(parameter_packet.client.clone());
+        let app_root_dir_key = unwrap_option!(parameter_packet.clone().app_root_dir_key, "");
+        let app_root_dir = unwrap_result!(dir_helper.get(&app_root_dir_key));
+        assert_eq!(app_root_dir.get_sub_directories().len(), 2);
+        let dest_dir = unwrap_result!(dir_helper.get(&dest_dir_key));
+        assert_eq!(dest_dir.get_sub_directories().len(), 1);
     }
 }


### PR DESCRIPTION
nfs move directory api error fixed and test case updated for move and copy.
Additional ffi api added for fetching file metadata from dns and nfs in the ffi interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/272)
<!-- Reviewable:end -->
