### PR TITLE
test/dns: add tests to interrupted composed operations

### DIFF
--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -695,6 +695,11 @@ impl Client {
     pub fn issued_deletes(&self) -> u64 {
         self.issued_deletes
     }
+
+    #[cfg(all(test, feature = "use-mock-routing"))]
+    pub fn set_network_limits(&mut self, max_ops_count: Option<u64>) {
+        self.routing.set_network_limits(max_ops_count);
+    }
 }
 
 /// //////////////////////////////////////////////////////////////

--- a/src/core/client/non_networking_test_framework/mod.rs
+++ b/src/core/client/non_networking_test_framework/mod.rs
@@ -96,6 +96,7 @@ fn sync_disk_storage(memory_storage: &HashMap<XorName, Vec<u8>>) {
 pub struct RoutingMock {
     sender: mpsc::Sender<Event>,
     client_auth: Authority,
+    max_ops_countdown: Option<u64>,
 }
 
 impl RoutingMock {
@@ -118,6 +119,7 @@ impl RoutingMock {
         Ok(RoutingMock {
             sender: sender,
             client_auth: client_auth,
+            max_ops_countdown: None,
         })
     }
 
@@ -133,11 +135,39 @@ impl RoutingMock {
         let cloned_sender = self.sender.clone();
         let client_auth = self.client_auth.clone();
 
+        let err = if self.max_ops_countdown == Some(0) {
+            Some(GetError::NetworkOther("Max operations exhausted".to_string()))
+        } else {
+            None
+        };
+
+        if err == None {
+            if let Some(ref mut count) = self.max_ops_countdown {
+                *count -= 1;
+            }
+        }
+
         let _ = thread::spawn(move || {
             thread::sleep(Duration::from_millis(SIMULATED_NETWORK_DELAY_GETS_POSTS_MS));
             let data_name = data_id.name();
             let nae_auth = Authority::NaeManager(data_name);
             let request = Request::Get(data_id.clone(), msg_id.clone());
+
+            if let Some(reason) = err {
+                let ext_err = match serialise(&reason) {
+                    Ok(serialised_err) => serialised_err,
+                    Err(err) => {
+                        warn!("Could not serialise client-vault error - {:?}", err);
+                        Vec::new()
+                    }
+                };
+                let event =
+                    RoutingMock::construct_failure_resp(nae_auth, client_auth, request, ext_err);
+                if let Err(error) = cloned_sender.send(event) {
+                    error!("Delete-Response mpsc-send failure: {:?}", error);
+                }
+                return;
+            }
 
             match unwrap_result!(data_store.lock()).get(&data_name) {
                 Some(raw_data) => {
@@ -199,7 +229,7 @@ impl RoutingMock {
         Ok(())
     }
 
-    pub fn send_put_request(&self,
+    pub fn send_put_request(&mut self,
                             _dst: Authority,
                             data: Data,
                             msg_id: MessageId)
@@ -216,7 +246,10 @@ impl RoutingMock {
         let request = Request::Put(data.clone(), msg_id.clone());
 
         let mut data_store_mutex_guard = unwrap_result!(data_store.lock());
-        let err = if data_store_mutex_guard.contains_key(&data_name) {
+        let err = if self.max_ops_countdown == Some(0) {
+            Some(MutationError::NetworkOther("Max operations exhausted"
+                                             .to_string()))
+        } else if data_store_mutex_guard.contains_key(&data_name) {
             match data {
                 Data::Immutable(_) => {
                     match deserialise(unwrap_option!(data_store_mutex_guard.get(&data_name),
@@ -243,6 +276,12 @@ impl RoutingMock {
         } else {
             Some(MutationError::NetworkOther("Serialisation error".to_owned()))
         };
+
+        if err == None {
+            if let Some(ref mut count) = self.max_ops_countdown {
+                *count -= 1;
+            }
+        }
 
         let _ = thread::spawn(move || {
             thread::sleep(Duration::from_millis(SIMULATED_NETWORK_DELAY_PUTS_DELETS_MS));
@@ -275,7 +314,7 @@ impl RoutingMock {
         Ok(())
     }
 
-    pub fn send_post_request(&self,
+    pub fn send_post_request(&mut self,
                              _dst: Authority,
                              data: Data,
                              msg_id: MessageId)
@@ -291,7 +330,10 @@ impl RoutingMock {
 
         let mut data_store_mutex_guard = unwrap_result!(data_store.lock());
         let err = if data_store_mutex_guard.contains_key(&data_name) {
-            if let Data::Structured(ref sd_new) = data {
+            if self.max_ops_countdown == Some(0) {
+                Some(MutationError::NetworkOther("Max operations exhausted"
+                                                 .to_string()))
+            } else if let Data::Structured(ref sd_new) = data {
                 match (serialise(&data),
                        deserialise(unwrap_option!(data_store_mutex_guard.get(&data_name),
                                                   "Programming Error - Report this as a Bug."))) {
@@ -312,6 +354,12 @@ impl RoutingMock {
         } else {
             Some(MutationError::NoSuchData)
         };
+
+        if err == None {
+            if let Some(ref mut count) = self.max_ops_countdown {
+                *count -= 1;
+            }
+        }
 
         let _ = thread::spawn(move || {
             thread::sleep(Duration::from_millis(SIMULATED_NETWORK_DELAY_PUTS_DELETS_MS));
@@ -344,7 +392,7 @@ impl RoutingMock {
         Ok(())
     }
 
-    pub fn send_delete_request(&self,
+    pub fn send_delete_request(&mut self,
                                _dst: Authority,
                                data: Data,
                                msg_id: MessageId)
@@ -359,7 +407,10 @@ impl RoutingMock {
         let request = Request::Delete(data.clone(), msg_id.clone());
 
         let mut data_store_mutex_guard = unwrap_result!(data_store.lock());
-        let err = if data_store_mutex_guard.contains_key(&data_name) {
+        let err = if self.max_ops_countdown == Some(0) {
+            Some(MutationError::NetworkOther("Max operations exhausted"
+                                             .to_string()))
+        } else if data_store_mutex_guard.contains_key(&data_name) {
             if let Data::Structured(ref sd_new) = data {
                 match (serialise(&data),
                        deserialise(unwrap_option!(data_store_mutex_guard.get(&data_name),
@@ -381,6 +432,12 @@ impl RoutingMock {
         } else {
             Some(MutationError::NoSuchData)
         };
+
+        if err == None {
+            if let Some(ref mut count) = self.max_ops_countdown {
+                *count -= 1;
+            }
+        }
 
         let _ = thread::spawn(move || {
             thread::sleep(Duration::from_millis(SIMULATED_NETWORK_DELAY_PUTS_DELETS_MS));
@@ -458,6 +515,11 @@ impl RoutingMock {
             dst: dst,
             response: response,
         }
+    }
+
+    #[cfg(test)]
+    pub fn set_network_limits(&mut self, max_ops_count: Option<u64>) {
+        self.max_ops_countdown = max_ops_count;
     }
 }
 

--- a/src/dns/dns_operations/mod.rs
+++ b/src/dns/dns_operations/mod.rs
@@ -344,11 +344,14 @@ struct Dns {
 mod test {
     use super::*;
     use core::client::Client;
+    use core::errors::CoreError;
     use core::utility::{generate_random_string, test_utils};
     use dns::errors::DnsError;
     use nfs::AccessLevel;
+    use nfs::errors::NfsError;
     use nfs::metadata::directory_key::DirectoryKey;
     use routing::{XorName, XOR_NAME_LEN};
+    use safe_network_common::client_errors::GetError;
     use sodiumoxide::crypto::box_;
     use std::sync::{Arc, Mutex};
 
@@ -596,5 +599,42 @@ mod test {
         assert_eq!(services.len(), services_vec.len());
         assert!(services.iter()
                         .all(|&(ref a, _)| services_vec.iter().find(|b| *a == **b).is_some()));
+    }
+
+    #[test]
+    fn register_dns_internal_error_recovery() {
+        let client = Arc::new(Mutex::new(unwrap_result!(test_utils::get_client())));
+        let dns_operations = unwrap_result!(DnsOperations::new(client.clone()));
+        let dns_name = unwrap_result!(generate_random_string(10));
+        let messaging_keypair = box_::gen_keypair();
+        let owners = vec![unwrap_result!(unwrap_result!(client.lock()).get_public_signing_key())
+                              .clone()];
+        let secret_signing_key = unwrap_result!(unwrap_result!(client.lock())
+                                                    .get_secret_signing_key())
+                                     .clone();
+        // Limit of `Some(2)` would prevent the mutation to happen. We want one
+        // `Mutation` exactly at this point
+        client.lock().unwrap().set_network_limits(Some(3));
+        match dns_operations.register_dns(dns_name.clone(),
+                                          &messaging_keypair.0,
+                                          &messaging_keypair.1,
+                                          &vec![],
+                                          owners.clone(),
+                                          &secret_signing_key,
+                                          None) {
+            Err(DnsError::NfsError(NfsError::CoreError(CoreError::GetFailure {
+                reason: GetError::NetworkOther(ref s), ..
+            }))) if s == "Max operations exhausted" => (),
+            Ok(()) => panic!("Operation unexpectedly had succeed"),
+            Err(e) => panic!("Unexpected error {:?}", e),
+        }
+        client.lock().unwrap().set_network_limits(None);
+        unwrap_result!(dns_operations.register_dns(dns_name.clone(),
+                                                   &messaging_keypair.0,
+                                                   &messaging_keypair.1,
+                                                   &vec![],
+                                                   owners.clone(),
+                                                   &secret_signing_key,
+                                                   None));
     }
 }


### PR DESCRIPTION
Add tests to ensure that interruped composed operations won't leave the
network in an invalid state and retrying the same operation later will
succeed.

This is Spandan's explanation of how operations should behave:

> Error recovery for a composite operation which in its previous
> invocation had failed in one of the intermediary steps. So if
> Operation A does 3 PUTs of SD and say 2nd PUT fails. When application
> retries A later the 1st PUT is going to fail because it had succeeded
> last time. Instead of bailing out at this point, do a GET. If not
> present return the error which PUT returned. If GET is successful,
> verify that you are the owner of the SD. If not return the error which
> PUT returned. If verification is successful then it's evident that
> this PUT had succeeded in some other prior session of ours. Continue
> to the 2nd PUT and then to 3rd and so on.

The commit that fixed operations' behaviour (with missing tests) is
commit 6de85caea464f5db936d681a82ff596d1ca93d62.

r? @ustulation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/276)
<!-- Reviewable:end -->
