### PR TITLE
fix/unwinding: correct order of destruction

### DIFF
--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -78,9 +78,9 @@ impl Client {
         let (routing_sender, routing_receiver) = mpsc::channel();
         let (network_event_sender, network_event_receiver) = mpsc::channel();
 
-        let routing = try!(Routing::new(routing_sender, None));
         let (message_queue, raii_joiner) = MessageQueue::new(routing_receiver,
                                                              vec![network_event_sender]);
+        let routing = try!(Routing::new(routing_sender, None));
 
         match try!(network_event_receiver.recv()) {
             NetworkEvent::Connected => (),
@@ -117,9 +117,9 @@ impl Client {
         let (routing_sender, routing_receiver) = mpsc::channel();
         let (network_event_sender, network_event_receiver) = mpsc::channel();
 
-        let routing = try!(Routing::new(routing_sender, Some(id_packet)));
         let (message_queue, raii_joiner) = MessageQueue::new(routing_receiver,
                                                              vec![network_event_sender]);
+        let routing = try!(Routing::new(routing_sender, Some(id_packet)));
 
         match try!(network_event_receiver.recv()) {
             NetworkEvent::Connected => (),
@@ -199,9 +199,9 @@ impl Client {
             let (routing_sender, routing_receiver) = mpsc::channel();
             let (network_event_sender, network_event_receiver) = mpsc::channel();
 
-            let routing = try!(Routing::new(routing_sender, Some(id_packet)));
             let (message_queue, raii_joiner) = MessageQueue::new(routing_receiver,
                                                                  vec![network_event_sender]);
+            let routing = try!(Routing::new(routing_sender, Some(id_packet)));
 
             match try!(network_event_receiver.recv()) {
                 NetworkEvent::Connected => (),


### PR DESCRIPTION
Routing needs to be destroyed first for mpsc::Sender given to it to be destroyed which will trigger the exit of thread running MessageQueue and thus cause raii_joiner to exit. This order is respected in Client struct but in the stack frame of constructors (create/login functions) it was not. This fix resolves that as things that come later in the frame will be destroyed first so routing needs to come after MessageQueue because it needs to be destroyed before MessageQueue for raii_joiner to exit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/296)
<!-- Reviewable:end -->
