### PR TITLE
feat/ffi: add get_account_info function

### DIFF
--- a/src/core/client/response_getter.rs
+++ b/src/core/client/response_getter.rs
@@ -96,7 +96,8 @@ impl GetAccountInfoResponseGetter {
     }
 
     /// Get result from the network as informed by MessageQueue. This is blocking. Tuple fields of
-    /// result are `(data_stored, space_available)`.
+    /// result are `(data_stored, space_available)`. `data_stored` means number of chunks Put.
+    /// `space_available` means number of chunks which can still be Put.
     pub fn get(&self) -> Result<(u64, u64), CoreError> {
         let (_, ref data_receiver) = self.data_channel;
         let res = data_receiver.recv();


### PR DESCRIPTION
Exports the Client::get_account_info function to the ffi layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/299)
<!-- Reviewable:end -->
