### PR TITLE
fix/ffi: mark unsafe functions as unsafe

### DIFF
--- a/src/ffi/macros.rs
+++ b/src/ffi/macros.rs
@@ -35,7 +35,7 @@ macro_rules! ffi_ptr_try {
             Err(error) => {
                 let decorator = ::std::iter::repeat('-').take(50).collect::<String>();
                 error!("\n\n {}\n| {:?}\n {}\n\n", decorator, error, decorator);
-                unsafe { ::std::ptr::write($out, error.into()) };
+                ::std::ptr::write($out, error.into());
                 return ::std::ptr::null();
             },
         }


### PR DESCRIPTION
This fixes the `not_unsafe_ptr_arg_deref` Clippy lint: Dereferencing a
pointer argument is not safe, so all functions that do that must be
declared `unsafe`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/302)
<!-- Reviewable:end -->
