### PR TITLE
refactor/credentials: work with a single credential

### DIFF
--- a/examples/client_stress_test.rs
+++ b/examples/client_stress_test.rs
@@ -52,7 +52,6 @@ use safe_core::core::client::Client;
 use docopt::Docopt;
 use routing::{Data, ImmutableData, StructuredData};
 use rand::{Rng, SeedableRng};
-use rand::distributions::{IndependentSample, Range};
 use sodiumoxide::crypto::sign::{PublicKey, SecretKey};
 
 
@@ -110,18 +109,15 @@ fn main() {
     });
 
     // Create account
-    let keyword: String = rng.gen_ascii_chars().take(20).collect();
-    let password: String = rng.gen_ascii_chars().take(20).collect();
-    let pin_range = Range::new(0u16, 9999);
-    let pin = pin_range.ind_sample(&mut rng).to_string();
+    let pass_phrase: String = rng.gen_ascii_chars().take(20).collect();
 
     let mut client = if args.flag_get_only {
-        unwrap!(Client::log_in(keyword.clone(), pin.clone(), password.clone()))
+        unwrap!(Client::log_in(&pass_phrase))
     } else {
         println!("\n\tAccount Creation");
         println!("\t================");
         println!("\nTrying to create an account ...");
-        unwrap!(Client::create_account(keyword.clone(), pin.clone(), password.clone()))
+        unwrap!(Client::create_account(&pass_phrase))
     };
     println!("Logged in successfully !!");
     let public_key = *unwrap!(client.get_public_signing_key());

--- a/examples/nfs_api.rs
+++ b/examples/nfs_api.rs
@@ -56,40 +56,24 @@ use safe_core::nfs::helper::file_helper::FileHelper;
 use safe_core::nfs::helper::writer::Mode;
 
 fn create_account() -> Result<Client, NfsError> {
-    let mut pin = String::new();
-    let mut keyword = String::new();
-    let mut password = String::new();
+    let mut pass_phrase = String::new();
 
     println!("\n\tAccount Creation");
     println!("\t================");
 
-    println!("\n------------ Enter Keyword ---------------");
-    let _ = std::io::stdin().read_line(&mut keyword);
-
-    println!("\n\n------------ Enter Password --------------");
-    let _ = std::io::stdin().read_line(&mut password);
-
-    loop {
-        println!("\n\n--------- Enter PIN (4 Digits) -----------");
-        let _ = std::io::stdin().read_line(&mut pin);
-        pin = pin.trim().to_string();
-        if pin.parse::<u16>().is_ok() && pin.len() == 4 {
-            break;
-        }
-        println!("ERROR: PIN is not 4 Digits !!");
-        pin.clear();
-    }
+    println!("\n------------ Enter Pass-phrase ---------------");
+    let _ = std::io::stdin().read_line(&mut pass_phrase);
 
     // Account Creation
     println!("\nTrying to create an account ...");
-    let _ = unwrap!(Client::create_account(keyword.clone(), pin.clone(), password.clone()));
+    let _ = unwrap!(Client::create_account(&pass_phrase));
     println!("Account Created Successfully !!");
     println!("\n\n\tAuto Account Login");
     println!("\t==================");
 
     // Log into the created account
     println!("\nTrying to log into the created account using supplied credentials ...");
-    let client = try!(Client::log_in(keyword, pin, password));
+    let client = try!(Client::log_in(&pass_phrase));
     println!("Account Login Successful !!");
     Ok(client)
 }

--- a/examples/safe_client.rs
+++ b/examples/safe_client.rs
@@ -61,9 +61,7 @@ const MOCK_NETWORK: bool = false;
 fn main() {
     unwrap!(maidsafe_utilities::log::init(true));
 
-    let mut keyword = String::new();
-    let mut password = String::new();
-    let mut pin = String::new();
+    let mut pass_phrase = String::new();
 
     println!("\nDo you already have an account created (enter Y for yes) ?");
 
@@ -75,28 +73,14 @@ fn main() {
         println!("\n\tAccount Creation");
         println!("\t================");
 
-        println!("\n------------ Enter Keyword ---------------");
-        let _ = std::io::stdin().read_line(&mut keyword);
-
-        println!("\n\n------------ Enter Password --------------");
-        let _ = std::io::stdin().read_line(&mut password);
-
-        loop {
-            println!("\n\n--------- Enter PIN (4 Digits) -----------");
-            let _ = std::io::stdin().read_line(&mut pin);
-            pin = pin.trim().to_string();
-            if pin.parse::<u16>().is_ok() && pin.len() == 4 {
-                break;
-            }
-            println!("ERROR: PIN is not 4 Digits !!");
-            pin.clear();
-        }
+        println!("\n------------ Enter Pass-phrase ---------------");
+        let _ = std::io::stdin().read_line(&mut pass_phrase);
 
         // Account Creation
         {
             println!("\nTrying to create an account ...");
 
-            let _ = unwrap!(Client::create_account(keyword.clone(), pin.clone(), password.clone()));
+            let _ = unwrap!(Client::create_account(&pass_phrase));
             println!("Account Created Successfully !!");
         }
 
@@ -107,7 +91,7 @@ fn main() {
         {
             println!("\nTrying to log into the created account using supplied credentials ...");
 
-            let _ = unwrap!(Client::log_in(keyword, pin, password));
+            let _ = unwrap!(Client::log_in(&pass_phrase));
             println!("Account Login Successful !!");
         }
     }
@@ -116,30 +100,15 @@ fn main() {
     println!("\t====================");
 
     loop {
-        keyword = String::new();
-        password = String::new();
+        pass_phrase = String::new();
 
-        println!("\n------------ Enter Keyword ---------------");
-        let _ = std::io::stdin().read_line(&mut keyword);
-
-        println!("\n\n------------ Enter Password --------------");
-        let _ = std::io::stdin().read_line(&mut password);
-
-        loop {
-            pin = String::new();
-            println!("\n\n--------- Enter PIN (4 Digits) -----------");
-            let _ = std::io::stdin().read_line(&mut pin);
-            pin = pin.trim().to_string();
-            if pin.parse::<u16>().is_ok() && pin.len() == 4 {
-                break;
-            }
-            println!("ERROR: PIN is not 4 Digits !!");
-        }
+        println!("\n------------ Enter Pass-phrase ---------------");
+        let _ = std::io::stdin().read_line(&mut pass_phrase);
 
         // Log into the created account
         {
             println!("\nTrying to log in ...");
-            match Client::log_in(keyword, pin, password) {
+            match Client::log_in(&pass_phrase) {
                 Ok(mut client) => {
                     println!("Account Login Successful !!");
                     if MOCK_NETWORK {

--- a/examples/self_authentication.rs
+++ b/examples/self_authentication.rs
@@ -50,9 +50,7 @@ use safe_network_common::client_errors::MutationError;
 fn main() {
     unwrap!(maidsafe_utilities::log::init(true));
 
-    let mut keyword = String::new();
-    let mut password = String::new();
-    let mut pin = String::new();
+    let mut pass_phrase = String::new();
 
     println!("\nDo you already have an account created (enter Y for yes) ?");
 
@@ -64,28 +62,14 @@ fn main() {
         println!("\n\tAccount Creation");
         println!("\t================");
 
-        println!("\n------------ Enter Keyword ---------------");
-        let _ = std::io::stdin().read_line(&mut keyword);
-
-        println!("\n\n------------ Enter Password --------------");
-        let _ = std::io::stdin().read_line(&mut password);
-
-        loop {
-            println!("\n\n--------- Enter PIN (4 Digits) -----------");
-            let _ = std::io::stdin().read_line(&mut pin);
-            pin = pin.trim().to_string();
-            if pin.parse::<u16>().is_ok() && pin.len() == 4 {
-                break;
-            }
-            println!("ERROR: PIN is not 4 Digits !!");
-            pin.clear();
-        }
+        println!("\n------------ Enter Pass-phrase ---------------");
+        let _ = std::io::stdin().read_line(&mut pass_phrase);
 
         // Account Creation
         {
             println!("\nTrying to create an account ...");
 
-            match Client::create_account(keyword.clone(), pin.clone(), password.clone()) {
+            match Client::create_account(&pass_phrase) {
                 Ok(_) => (),
                 Err(CoreError::MutationFailure { reason: MutationError::AccountExists, .. }) => {
                     println!("ERROR: This domain is already taken. Please retry with different \
@@ -104,7 +88,7 @@ fn main() {
         {
             println!("\nTrying to log into the created account using supplied credentials ...");
 
-            let _ = unwrap!(Client::log_in(keyword, pin, password));
+            let _ = unwrap!(Client::log_in(&pass_phrase));
             println!("Account Login Successful !!");
         }
     }
@@ -113,30 +97,15 @@ fn main() {
     println!("\t====================");
 
     loop {
-        keyword = String::new();
-        password = String::new();
+        pass_phrase = String::new();
 
-        println!("\n------------ Enter Keyword ---------------");
-        let _ = std::io::stdin().read_line(&mut keyword);
-
-        println!("\n\n------------ Enter Password --------------");
-        let _ = std::io::stdin().read_line(&mut password);
-
-        loop {
-            pin = String::new();
-            println!("\n\n--------- Enter PIN (4 Digits) -----------");
-            let _ = std::io::stdin().read_line(&mut pin);
-            pin = pin.trim().to_string();
-            if pin.parse::<u16>().is_ok() && pin.len() == 4 {
-                break;
-            }
-            println!("ERROR: PIN is not 4 Digits !!");
-        }
+        println!("\n------------ Enter Pass-phrase ---------------");
+        let _ = std::io::stdin().read_line(&mut pass_phrase);
 
         // Log into the created account
         {
             println!("\nTrying to log in ...");
-            match Client::log_in(keyword, pin, password) {
+            match Client::log_in(&pass_phrase) {
                 Ok(_) => {
                     println!("Account Login Successful !!");
                     break;

--- a/examples/simulate_browser.rs
+++ b/examples/simulate_browser.rs
@@ -62,33 +62,18 @@ const DEFAULT_SERVICE: &'static str = "www";
 const HOME_PAGE_FILE_NAME: &'static str = "index.html";
 
 fn handle_login() -> Arc<Mutex<Client>> {
-    let mut pin = String::new();
-    let mut keyword = String::new();
-    let mut password = String::new();
+    let mut pass_phrase = String::new();
 
     println!("\n\tAccount Creation");
     println!("\t================");
 
-    println!("\n------------ Enter Keyword ---------------");
-    let _ = std::io::stdin().read_line(&mut keyword);
-
-    println!("\n\n------------ Enter Password --------------");
-    let _ = std::io::stdin().read_line(&mut password);
-    loop {
-        println!("\n\n--------- Enter PIN (4 Digits) -----------");
-        let _ = std::io::stdin().read_line(&mut pin);
-        pin = pin.trim().to_string();
-        if pin.parse::<u16>().is_ok() && pin.len() == 4 {
-            break;
-        }
-        println!("ERROR: PIN is not 4 Digits !!");
-        pin.clear();
-    }
+    println!("\n------------ Enter Pass-phrase ---------------");
+    let _ = std::io::stdin().read_line(&mut pass_phrase);
 
     // Account Creation
     {
         println!("\nTrying to create an account ...");
-        let _ = unwrap!(Client::create_account(keyword.clone(), pin.clone(), password.clone()));
+        let _ = unwrap!(Client::create_account(&pass_phrase));
         println!("Account Creation Successful !!");
     }
 
@@ -97,7 +82,7 @@ fn handle_login() -> Arc<Mutex<Client>> {
 
     // Log into the created account
     println!("\nTrying to log into the created account using supplied credentials ...");
-    Arc::new(Mutex::new(unwrap!(Client::log_in(keyword, pin, password))))
+    Arc::new(Mutex::new(unwrap!(Client::log_in(&pass_phrase))))
 }
 
 fn create_dns_record(client: Arc<Mutex<Client>>,

--- a/src/core/utility/mod.rs
+++ b/src/core/utility/mod.rs
@@ -117,6 +117,8 @@ mod test {
     use super::*;
     use sodiumoxide::crypto::box_;
 
+    const SIZE: usize = 10;
+
     #[test]
     fn hybrid_encrypt_decrypt() {
         // Identical Plain Texts
@@ -151,7 +153,6 @@ mod test {
 
     #[test]
     fn random_string() {
-        const SIZE: usize = 10;
         let str0 = unwrap!(generate_random_string(SIZE));
         let str1 = unwrap!(generate_random_string(SIZE));
         let str2 = unwrap!(generate_random_string(SIZE));
@@ -163,7 +164,6 @@ mod test {
 
     #[test]
     fn random_vector() {
-        const SIZE: usize = 10;
         let vec0 = unwrap!(generate_random_vector::<u8>(SIZE));
         let vec1 = unwrap!(generate_random_vector::<u8>(SIZE));
         let vec2 = unwrap!(generate_random_vector::<u8>(SIZE));
@@ -171,5 +171,26 @@ mod test {
         assert!(vec0 != vec1);
         assert!(vec0 != vec2);
         assert!(vec1 != vec2);
+    }
+
+    #[test]
+    fn secrets_derivation() {
+        // Random pass-phrase
+        {
+            let pass_phrase = unwrap!(generate_random_string(SIZE));
+            let (password, keyword, pin) = derive_secrets(&pass_phrase);
+            assert!(pin != keyword);
+            assert!(password != pin);
+            assert!(password != keyword);
+        }
+
+        // Nullary pass-phrase
+        {
+            let pass_phrase = String::new();
+            let (password, keyword, pin) = derive_secrets(&pass_phrase);
+            assert!(pin != keyword);
+            assert!(password != pin);
+            assert!(password != keyword);
+        }
     }
 }

--- a/src/core/utility/test_utils.rs
+++ b/src/core/utility/test_utils.rs
@@ -21,11 +21,8 @@ use sodiumoxide::crypto::sign;
 
 /// Generates a random mock client for testing
 pub fn get_client() -> Result<Client, CoreError> {
-    let pin = try!(utility::generate_random_string(10));
-    let keyword = try!(utility::generate_random_string(10));
-    let password = try!(utility::generate_random_string(10));
-
-    Client::create_account(keyword, pin, password)
+    let pass_phrase = try!(utility::generate_random_string(10));
+    Client::create_account(&pass_phrase)
 }
 
 /// Generates random public keys

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -153,16 +153,12 @@ pub unsafe extern "C" fn create_unregistered_client(ffi_handle: *mut *mut FfiHan
 /// a pointer to a pointer and must point to a valid pointer not junk, else the consequences are
 /// undefined.
 #[no_mangle]
-pub unsafe extern "C" fn create_account(c_keyword: *const c_char,
-                                        c_pin: *const c_char,
-                                        c_password: *const c_char,
+pub unsafe extern "C" fn create_account(c_pass_phrase: *const c_char,
                                         ffi_handle: *mut *mut FfiHandle)
                                         -> int32_t {
     catch_unwind_i32(|| {
-        let client =
-            ffi_try!(Client::create_account(ffi_try!(helper::c_char_ptr_to_string(c_keyword)),
-                                            ffi_try!(helper::c_char_ptr_to_string(c_pin)),
-                                            ffi_try!(helper::c_char_ptr_to_string(c_password))));
+        let pass_phrase = ffi_try!(helper::c_char_ptr_to_string(c_pass_phrase));
+        let client = ffi_try!(Client::create_account(&pass_phrase));
         *ffi_handle = cast_to_ffi_handle(client);
         0
     })
@@ -173,15 +169,12 @@ pub unsafe extern "C" fn create_account(c_keyword: *const c_char,
 /// a pointer to a pointer and must point to a valid pointer not junk, else the consequences are
 /// undefined.
 #[no_mangle]
-pub unsafe extern "C" fn log_in(c_keyword: *const c_char,
-                                c_pin: *const c_char,
-                                c_password: *const c_char,
+pub unsafe extern "C" fn log_in(c_pass_phrase: *const c_char,
                                 ffi_handle: *mut *mut FfiHandle)
                                 -> int32_t {
     catch_unwind_i32(|| {
-        let client = ffi_try!(Client::log_in(ffi_try!(helper::c_char_ptr_to_string(c_keyword)),
-                                             ffi_try!(helper::c_char_ptr_to_string(c_pin)),
-                                             ffi_try!(helper::c_char_ptr_to_string(c_password))));
+        let pass_phrase = ffi_try!(helper::c_char_ptr_to_string(c_pass_phrase));
+        let client = ffi_try!(Client::log_in(&pass_phrase));
         *ffi_handle = cast_to_ffi_handle(client);
         0
     })
@@ -636,9 +629,7 @@ mod test {
 
     #[test]
     fn account_creation_and_login() {
-        let cstring_pin = unwrap!(generate_random_cstring(10));
-        let cstring_keyword = unwrap!(generate_random_cstring(10));
-        let cstring_password = unwrap!(generate_random_cstring(10));
+        let cstring_pass_phrase = unwrap!(generate_random_cstring(10));
 
         {
             let mut client_handle: *mut FfiHandle = ptr::null_mut();
@@ -646,10 +637,7 @@ mod test {
             unsafe {
                 let ptr_to_client_handle = &mut client_handle;
 
-                assert_eq!(create_account(cstring_keyword.as_ptr(),
-                                          cstring_pin.as_ptr(),
-                                          cstring_password.as_ptr(),
-                                          ptr_to_client_handle),
+                assert_eq!(create_account(cstring_pass_phrase.as_ptr(), ptr_to_client_handle),
                            0);
             }
 
@@ -663,10 +651,7 @@ mod test {
             unsafe {
                 let ptr_to_client_handle = &mut client_handle;
 
-                assert_eq!(log_in(cstring_keyword.as_ptr(),
-                                  cstring_pin.as_ptr(),
-                                  cstring_password.as_ptr(),
-                                  ptr_to_client_handle),
+                assert_eq!(log_in(cstring_pass_phrase.as_ptr(), ptr_to_client_handle),
                            0);
             }
 


### PR DESCRIPTION
Instead of requiring user to type in all 3 of PIN, Keyword and Password, have them type only one secure pass-phrase and derive the required credentials internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/303)
<!-- Reviewable:end -->
