### PR TITLE
fix/ffi_move: fetch copy or moved directory

### DIFF
--- a/src/ffi/nfs/modify_dir.rs
+++ b/src/ffi/nfs/modify_dir.rs
@@ -18,6 +18,7 @@
 use ffi::{Action, ParameterPacket, ResponseType, helper};
 use ffi::errors::FfiError;
 use nfs::helper::directory_helper::DirectoryHelper;
+use time;
 
 #[derive(RustcDecodable, Debug)]
 pub struct ModifyDir {
@@ -64,6 +65,7 @@ impl Action for ModifyDir {
             dir_to_modify.get_mut_metadata().set_user_metadata(metadata);
         }
 
+        dir_to_modify.get_mut_metadata().set_modified_time(time::now_utc());
         let _ = try!(directory_helper.update(&dir_to_modify));
 
         Ok(None)

--- a/src/ffi/nfs/modify_file.rs
+++ b/src/ffi/nfs/modify_file.rs
@@ -19,6 +19,7 @@ use ffi::{Action, ParameterPacket, ResponseType, helper};
 use ffi::errors::FfiError;
 use nfs::helper::file_helper::FileHelper;
 use nfs::helper::writer::Mode;
+use time;
 
 #[derive(RustcDecodable, Debug)]
 pub struct ModifyFile {
@@ -75,6 +76,7 @@ impl Action for ModifyFile {
         }
 
         if metadata_updated {
+            file.get_mut_metadata().set_modified_time(time::now_utc());
             let _ = try!(file_helper.update_metadata(file.clone(), &mut dir_of_file));
         }
 

--- a/src/ffi/nfs/move_dir.rs
+++ b/src/ffi/nfs/move_dir.rs
@@ -38,12 +38,12 @@ impl MoveDirectory {
                      -> Result<DirectoryListing, FfiError> {
         let start_dir_key = if shared {
             try!(params.clone()
-                .safe_drive_dir_key
-                .ok_or(FfiError::from("Safe Drive directory key is not present")))
+                       .safe_drive_dir_key
+                       .ok_or(FfiError::from("Safe Drive directory key is not present")))
         } else {
             try!(params.clone()
-                .app_root_dir_key
-                .ok_or(FfiError::from("Application directory key is not present")))
+                       .app_root_dir_key
+                       .ok_or(FfiError::from("Application directory key is not present")))
         };
 
         let tokens = helper::tokenise_path(path, false);
@@ -61,60 +61,59 @@ impl Action for MoveDirectory {
             return Err(FfiError::PermissionDenied);
         }
         let directory_helper = DirectoryHelper::new(params.client.clone());
-        let mut src_dir =
-            try!(self.get_directory(&params, self.is_src_path_shared, &self.src_path));
-        let mut dest_dir =
-            try!(self.get_directory(&params, self.is_dest_path_shared, &self.dest_path));
+        let mut src_dir = try!(self.get_directory(&params,
+                                                  self.is_src_path_shared,
+                                                  &self.src_path));
+        let mut dest_dir = try!(self.get_directory(&params,
+                                                   self.is_dest_path_shared,
+                                                   &self.dest_path));
         if dest_dir.find_sub_directory(src_dir.get_metadata().get_name()).is_some() {
             return Err(FfiError::from(DirectoryAlreadyExistsWithSameName));
         }
         let org_parent_of_src_dir = try!(src_dir.get_metadata()
-            .get_parent_dir_key()
-            .cloned()
-            .ok_or(FfiError::from("Parent directory not found")));
+                                                .get_parent_dir_key()
+                                                .cloned()
+                                                .ok_or(FfiError::from("Parent directory not \
+                                                                       found")));
         if self.retain_source {
             let name = src_dir.get_metadata().get_name().to_owned();
             let user_metadata = src_dir.get_metadata().get_user_metadata().to_owned();
             let access_level = src_dir.get_metadata().get_access_level().clone();
             let created_time = *src_dir.get_metadata().get_created_time();
             let modified_time = *src_dir.get_metadata().get_modified_time();
-            let mut dir = try!(DirectoryListing::new(name,
-                                                     src_dir.get_metadata()
-                                                         .get_key()
-                                                         .get_type_tag(),
-                                                     user_metadata,
-                                                     src_dir.get_metadata()
-                                                         .get_key()
-                                                         .is_versioned(),
-                                                     access_level,
-                                                     src_dir.get_metadata()
-                                                         .get_parent_dir_key()
-                                                         .cloned()));
+            let (mut dir, _) = try!(directory_helper.create(name,
+                                                            src_dir.get_metadata()
+                                                                   .get_key()
+                                                                   .get_type_tag(),
+                                                            user_metadata,
+                                                            src_dir.get_metadata()
+                                                                   .get_key()
+                                                                   .is_versioned(),
+                                                            access_level,
+                                                            Some(&mut dest_dir)));
             src_dir.get_files().iter().all(|file| {
                 dir.get_mut_files().push(file.clone());
                 true
             });
             src_dir.get_sub_directories()
-                .iter()
-                .all(|sub_dir| {
-                    dir.get_mut_sub_directories().push(sub_dir.clone());
-                    true
-                });
+                   .iter()
+                   .all(|sub_dir| {
+                       dir.get_mut_sub_directories().push(sub_dir.clone());
+                       true
+                   });
             dir.get_mut_metadata().set_created_time(created_time);
             dir.get_mut_metadata().set_modified_time(modified_time);
-            src_dir = dir;
+            let _ = try!(directory_helper.update(&dir));
         } else {
             src_dir.get_mut_metadata()
-                .set_parent_dir_key(Some(dest_dir.get_metadata().get_key().clone()));
-        }
-        dest_dir.upsert_sub_directory(src_dir.get_metadata().clone());
-        let _ = try!(directory_helper.update(&dest_dir));
-        if !self.retain_source {
+                   .set_parent_dir_key(Some(dest_dir.get_metadata().get_key().clone()));
+            dest_dir.upsert_sub_directory(src_dir.get_metadata().clone());
+            let _ = try!(directory_helper.update(&dest_dir));
             let _ = try!(directory_helper.update(&src_dir));
             let mut parent_of_src_dir = try!(directory_helper.get(&org_parent_of_src_dir));
             // TODO (Spandan) - Fetch and issue a DELETE on the removed directory.
             let _dir_meta = try!(parent_of_src_dir.remove_sub_directory(src_dir.get_metadata()
-                .get_name()));
+                                                                               .get_name()));
             let _ = try!(directory_helper.update(&parent_of_src_dir));
         }
         Ok(None)


### PR DESCRIPTION
Create the directory moved or copied in the network. Previously the metadata was updated, and when the directory was fetched it returned error.
Similarly in copy file the copied file must generate a new id, instead of using the same id from the source

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_core/312)
<!-- Reviewable:end -->
