### PR TITLE
feat/ffi: add low level API to get SD/AD versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,9 @@ clone_depth: 50
 install:
   - ps: |
         $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
-        Start-FileDownload "$url/Install%20Rustup.ps1" -FileName "Install Rustup.ps1"
-        Start-FileDownload "$url/Build.ps1" -FileName "Build.ps1"
-        Start-FileDownload "$url/Run%20Tests.ps1" -FileName "Run Tests.ps1"
+        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
+        cmd /c curl -fsSL -o "Build.ps1" "$url/Build.ps1"
+        cmd /c curl -fsSL -o "Run Tests.ps1" "$url/Run%20Tests.ps1"
         . ".\Install Rustup.ps1"
 
 platform:

--- a/examples/nfs_api.rs
+++ b/examples/nfs_api.rs
@@ -48,7 +48,7 @@ use std::sync::{Arc, Mutex};
 
 use routing::XOR_NAME_LEN;
 use safe_core::core::client::Client;
-use safe_core::nfs::{self, AccessLevel};
+use safe_core::nfs::AccessLevel;
 use safe_core::nfs::errors::NfsError;
 use safe_core::nfs::directory_listing::DirectoryListing;
 use safe_core::nfs::helper::directory_helper::DirectoryHelper;
@@ -154,15 +154,8 @@ fn directory_operation(option: u32,
                         return Err(NfsError::ParameterIsNotValid);
                     }
 
-                    let tag_type = if versioned {
-                        nfs::VERSIONED_DIRECTORY_LISTING_TAG
-                    } else {
-                        nfs::UNVERSIONED_DIRECTORY_LISTING_TAG
-                    };
-
                     let directory_helper = DirectoryHelper::new(client.clone());
                     let _ = try!(directory_helper.create(name.clone(),
-                                                         tag_type,
                                                          vec![],
                                                          versioned,
                                                          access_level,

--- a/examples/simulate_browser.rs
+++ b/examples/simulate_browser.rs
@@ -53,7 +53,7 @@ use safe_core::core::client::Client;
 
 use safe_core::nfs::helper::file_helper::FileHelper;
 use safe_core::nfs::helper::directory_helper::DirectoryHelper;
-use safe_core::nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+use safe_core::nfs::AccessLevel;
 
 use safe_core::dns::errors::DnsError;
 use safe_core::dns::dns_operations::DnsOperations;
@@ -164,7 +164,6 @@ fn add_service(client: Arc<Mutex<Client>>, dns_operations: &DnsOperations) -> Re
 
     let dir_helper = DirectoryHelper::new(client.clone());
     let (dir_listing, _) = try!(dir_helper.create(service_home_dir_name,
-                                                  UNVERSIONED_DIRECTORY_LISTING_TAG,
                                                   vec![],
                                                   false,
                                                   AccessLevel::Public,

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -88,6 +88,8 @@ pub enum CoreError {
     SelfEncryption(SelfEncryptionError<SelfEncryptionStorageError>),
     /// The request has timed out
     RequestTimeout,
+    /// Invalid type tag for StructuredData
+    InvalidStructuredDataTypeTag,
 }
 
 impl<'a> From<&'a str> for CoreError {
@@ -207,6 +209,7 @@ impl Into<i32> for CoreError {
                                       ::Storage
                                       ::<SelfEncryptionStorageError>(
                                           SelfEncryptionStorageError(err))) => (*err).into(),
+            CoreError::InvalidStructuredDataTypeTag => CLIENT_ERROR_START_RANGE - 34,
         }
     }
 }
@@ -280,6 +283,9 @@ impl Debug for CoreError {
                 write!(formatter, "CoreError::SelfEncryption -> {:?}", error)
             }
             CoreError::RequestTimeout => write!(formatter, "CoreError::RequestTimeout"),
+            CoreError::InvalidStructuredDataTypeTag => {
+                write!(formatter, "CoreError::InvalidStructuredDataTypeTag")
+            }
         }
     }
 }
@@ -355,6 +361,9 @@ impl Display for CoreError {
                 write!(formatter, "Self-encryption error: {}", error)
             }
             CoreError::RequestTimeout => write!(formatter, "CoreError::RequestTimeout"),
+            CoreError::InvalidStructuredDataTypeTag => {
+                write!(formatter, "CoreError::InvalidStructuredDataTypeTag")
+            }
         }
     }
 }
@@ -385,6 +394,7 @@ impl Error for CoreError {
             CoreError::MutationFailure { ref reason, .. } => reason.description(),
             CoreError::SelfEncryption(ref error) => error.description(),
             CoreError::RequestTimeout => "Request has timed out",
+            CoreError::InvalidStructuredDataTypeTag => "Invalid Structured Data type tag",
         }
     }
 
@@ -428,7 +438,7 @@ mod test {
             ::<SelfEncryptionStorageError>(SelfEncryptionStorageError(Box::new(core_err_0)));
         let core_from_se_err = CoreError::from(se_err);
 
-        assert_eq!(<CoreError as Into<i32>>::into(core_err_1),
-                   <CoreError as Into<i32>>::into(core_from_se_err));
+        assert_eq!(<CoreError as Into::<i32>>::into(core_err_1),
+                   <CoreError as Into::<i32>>::into(core_from_se_err));
     }
 }

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -438,7 +438,7 @@ mod test {
             ::<SelfEncryptionStorageError>(SelfEncryptionStorageError(Box::new(core_err_0)));
         let core_from_se_err = CoreError::from(se_err);
 
-        assert_eq!(<CoreError as Into::<i32>>::into(core_err_1),
-                   <CoreError as Into::<i32>>::into(core_from_se_err));
+        assert_eq!(<CoreError as Into<i32>>::into(core_err_1),
+                   <CoreError as Into<i32>>::into(core_from_se_err));
     }
 }

--- a/src/dns/dns_operations/mod.rs
+++ b/src/dns/dns_operations/mod.rs
@@ -503,17 +503,14 @@ mod test {
 
         let mut services = vec![("www".to_string(),
                                  DirectoryKey::new(XorName([123; XOR_NAME_LEN]),
-                                                   15000,
                                                    false,
                                                    AccessLevel::Public)),
                                 ("blog".to_string(),
                                  DirectoryKey::new(XorName([123; XOR_NAME_LEN]),
-                                                   15000,
                                                    false,
                                                    AccessLevel::Public)),
                                 ("bad-ass".to_string(),
                                  DirectoryKey::new(XorName([123; XOR_NAME_LEN]),
-                                                   15000,
                                                    false,
                                                    AccessLevel::Public))];
 
@@ -584,7 +581,6 @@ mod test {
         // Add a service
         services.push(("added-service".to_string(),
                        DirectoryKey::new(XorName([126; XOR_NAME_LEN]),
-                                         15000,
                                          false,
                                          AccessLevel::Public)));
         let services_size = services.len();

--- a/src/ffi/dns/file.rs
+++ b/src/ffi/dns/file.rs
@@ -143,7 +143,7 @@ mod test {
     use dns::dns_operations::DnsOperations;
     use ffi::app::App;
     use ffi::test_utils;
-    use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+    use nfs::AccessLevel;
     use nfs::helper::directory_helper::DirectoryHelper;
     use nfs::helper::file_helper::FileHelper;
     use nfs::metadata::directory_key::DirectoryKey;
@@ -157,7 +157,6 @@ mod test {
         let mut app_dir = unwrap!(dir_helper.get(&app_dir_key));
 
         let (file_dir, _) = unwrap!(dir_helper.create("public-dir".to_string(),
-                                                      UNVERSIONED_DIRECTORY_LISTING_TAG,
                                                       vec![0u8; 0],
                                                       false,
                                                       AccessLevel::Public,

--- a/src/ffi/dns/service.rs
+++ b/src/ffi/dns/service.rs
@@ -171,7 +171,7 @@ mod test {
     use core::utility;
     use ffi::dns::long_name;
     use ffi::test_utils;
-    use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+    use nfs::AccessLevel;
     use nfs::helper::directory_helper::DirectoryHelper;
 
     #[test]
@@ -184,7 +184,6 @@ mod test {
         let public_name = unwrap!(utility::generate_random_string(10));
 
         let _ = unwrap!(dir_helper.create("test_dir".to_string(),
-                                          UNVERSIONED_DIRECTORY_LISTING_TAG,
                                           Vec::new(),
                                           false,
                                           AccessLevel::Public,
@@ -203,7 +202,6 @@ mod test {
         let mut app_root_dir = unwrap!(dir_helper.get(&app_root_dir_key));
 
         let _ = unwrap!(dir_helper.create("test_dir".to_string(),
-                                          UNVERSIONED_DIRECTORY_LISTING_TAG,
                                           Vec::new(),
                                           false,
                                           AccessLevel::Public,

--- a/src/ffi/errors.rs
+++ b/src/ffi/errors.rs
@@ -94,7 +94,10 @@ impl<'a> From<&'a str> for FfiError {
 
 impl From<CoreError> for FfiError {
     fn from(error: CoreError) -> FfiError {
-        FfiError::CoreError(Box::new(error))
+        match error {
+            CoreError::InvalidStructuredDataTypeTag => FfiError::InvalidStructuredDataTypeTag,
+            _ => FfiError::CoreError(Box::new(error)),
+        }
     }
 }
 

--- a/src/ffi/helper.rs
+++ b/src/ffi/helper.rs
@@ -22,7 +22,6 @@ use ffi::config::SAFE_DRIVE_DIR_NAME;
 use ffi::errors::FfiError;
 use libc::{int32_t, int64_t};
 use nfs::AccessLevel;
-use nfs::UNVERSIONED_DIRECTORY_LISTING_TAG;
 use nfs::directory_listing::DirectoryListing;
 use nfs::helper::directory_helper::DirectoryHelper;
 use nfs::metadata::directory_key::DirectoryKey;
@@ -116,7 +115,6 @@ pub fn get_safe_drive_key(client: Arc<Mutex<Client>>) -> Result<DirectoryKey, Ff
         None => {
             trace!("SAFEDrive does not exist - creating one.");
             let (created_dir, _) = try!(dir_helper.create(safe_drive_dir_name,
-                                                          UNVERSIONED_DIRECTORY_LISTING_TAG,
                                                           Vec::new(),
                                                           false,
                                                           AccessLevel::Private,

--- a/src/ffi/launcher_config_handler.rs
+++ b/src/ffi/launcher_config_handler.rs
@@ -20,7 +20,7 @@ use core::client::Client;
 use ffi::config::{LAUNCHER_GLOBAL_CONFIG_FILE_NAME, LAUNCHER_GLOBAL_DIRECTORY_NAME};
 use ffi::errors::FfiError;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+use nfs::AccessLevel;
 use nfs::directory_listing::DirectoryListing;
 use nfs::helper::directory_helper::DirectoryHelper;
 use nfs::helper::file_helper::FileHelper;
@@ -73,7 +73,6 @@ impl ConfigHandler {
                 let mut root_dir_listing = try!(dir_helper.get_user_root_directory_listing());
                 let app_dir_name = self.get_app_dir_name(&app_name, &root_dir_listing);
                 let dir_key = *try!(dir_helper.create(app_dir_name,
-                                                      UNVERSIONED_DIRECTORY_LISTING_TAG,
                                                       Vec::new(),
                                                       false,
                                                       AccessLevel::Private,

--- a/src/ffi/low_level_api/appendable_data.rs
+++ b/src/ffi/low_level_api/appendable_data.rs
@@ -666,6 +666,23 @@ pub unsafe extern "C" fn appendable_data_append(app: *const App,
     })
 }
 
+/// Get the current version of AppendableData by its handle
+#[no_mangle]
+pub extern "C" fn appendable_data_version(handle: AppendableDataHandle,
+                                          o_version: *mut u64)
+                                          -> i32 {
+    helper::catch_unwind_i32(|| {
+        unsafe {
+            *o_version = match *ffi_try!(unwrap!(object_cache()).get_ad(handle)) {
+                AppendableData::Pub(ref mut elt) => elt.get_version(),
+                AppendableData::Priv(ref mut elt) => elt.get_version(),
+            }
+        }
+
+        0
+    })
+}
+
 /// Free AppendableData handle
 #[no_mangle]
 pub extern "C" fn appendable_data_free(handle: AppendableDataHandle) -> i32 {

--- a/src/ffi/low_level_api/appendable_data.rs
+++ b/src/ffi/low_level_api/appendable_data.rs
@@ -681,6 +681,24 @@ pub unsafe extern "C" fn appendable_data_version(handle: AppendableDataHandle,
     })
 }
 
+/// Returns true if the app is one of the owners of the provided AppendableData.
+#[no_mangle]
+pub unsafe extern "C" fn appendable_data_is_owned(app: *const App,
+                                                  handle: AppendableDataHandle,
+                                                  o_is_owned: *mut bool) -> i32 {
+    helper::catch_unwind_i32(|| {
+        let client = (*app).get_client();
+        let my_key = *ffi_try!(unwrap!(client.lock()).get_public_signing_key());
+
+        *o_is_owned = match *ffi_try!(unwrap!(object_cache()).get_ad(handle)) {
+            AppendableData::Pub(ref mut elt) => elt.get_owner_keys().contains(&my_key),
+            AppendableData::Priv(ref mut elt) => elt.get_owner_keys().contains(&my_key),
+        };
+
+        0
+    })
+}
+
 /// Free AppendableData handle
 #[no_mangle]
 pub extern "C" fn appendable_data_free(handle: AppendableDataHandle) -> i32 {
@@ -762,6 +780,16 @@ mod tests {
                        0);
             assert_eq!(appendable_data_nth_data_id(&app, ad_h, 1, &mut got_immut_id_1_h),
                        0);
+
+            let mut is_owner = false;
+
+            // Check owners
+            assert_eq!(appendable_data_is_owned(&app, ad_h, &mut is_owner), 0);
+            assert_eq!(is_owner, true);
+
+            let app_fake = test_utils::create_app(false);
+            assert_eq!(appendable_data_is_owned(&app_fake, ad_h, &mut is_owner), 0);
+            assert_eq!(is_owner, false);
 
             assert_eq!(appendable_data_free(ad_h), 0);
         }
@@ -899,6 +927,15 @@ mod tests {
                        0);
             assert_eq!(appendable_data_nth_data_id(&app0, ad_priv_h, 1, &mut got_immut_id_1_h),
                        0);
+
+            // Check owners of appendable data
+            let mut is_owner = false;
+
+            assert_eq!(appendable_data_is_owned(&app0, ad_priv_h, &mut is_owner), 0);
+            assert_eq!(is_owner, true);
+
+            assert_eq!(appendable_data_is_owned(&app1, ad_priv_h, &mut is_owner), 0);
+            assert_eq!(is_owner, false);
 
             // Delete and restore private appendable data
             assert_eq!(appendable_data_remove_nth_data(ad_priv_h, 0), 0);

--- a/src/ffi/low_level_api/appendable_data.rs
+++ b/src/ffi/low_level_api/appendable_data.rs
@@ -668,16 +668,14 @@ pub unsafe extern "C" fn appendable_data_append(app: *const App,
 
 /// Get the current version of AppendableData by its handle
 #[no_mangle]
-pub extern "C" fn appendable_data_version(handle: AppendableDataHandle,
-                                          o_version: *mut u64)
-                                          -> i32 {
+pub unsafe extern "C" fn appendable_data_version(handle: AppendableDataHandle,
+                                                 o_version: *mut u64)
+                                                 -> i32 {
     helper::catch_unwind_i32(|| {
-        unsafe {
-            *o_version = match *ffi_try!(unwrap!(object_cache()).get_ad(handle)) {
-                AppendableData::Pub(ref mut elt) => elt.get_version(),
-                AppendableData::Priv(ref mut elt) => elt.get_version(),
-            }
-        }
+        *o_version = match *ffi_try!(unwrap!(object_cache()).get_ad(handle)) {
+            AppendableData::Pub(ref mut elt) => elt.get_version(),
+            AppendableData::Priv(ref mut elt) => elt.get_version(),
+        };
 
         0
     })

--- a/src/ffi/low_level_api/struct_data.rs
+++ b/src/ffi/low_level_api/struct_data.rs
@@ -449,11 +449,10 @@ fn struct_data_delete_impl(client: Arc<Mutex<Client>>,
 
 /// Get the current version of StructuredData by its handle
 #[no_mangle]
-pub extern "C" fn struct_data_version(handle: StructDataHandle, o_version: *mut u64) -> i32 {
+pub unsafe extern "C" fn struct_data_version(handle: StructDataHandle,
+                                             o_version: *mut u64) -> i32 {
     helper::catch_unwind_i32(|| {
-        unsafe {
-            *o_version = ffi_try!(unwrap!(object_cache()).get_sd(handle)).get_version();
-        }
+        *o_version = ffi_try!(unwrap!(object_cache()).get_sd(handle)).get_version();
         0
     })
 }

--- a/src/ffi/low_level_api/struct_data.rs
+++ b/src/ffi/low_level_api/struct_data.rs
@@ -56,8 +56,8 @@ pub unsafe extern "C" fn struct_data_new(app: *const App,
         let sd = match type_tag {
             ::UNVERSIONED_STRUCT_DATA_TYPE_TAG => {
                 let raw_data = ffi_try!(ffi_try!(unwrap!(object_cache())
-                        .get_cipher_opt(cipher_opt_h))
-                    .encrypt(app, &plain_text));
+                                                     .get_cipher_opt(cipher_opt_h))
+                                            .encrypt(app, &plain_text));
 
                 ffi_try!(unversioned::create(client,
                                              type_tag,
@@ -70,15 +70,16 @@ pub unsafe extern "C" fn struct_data_new(app: *const App,
                                              None))
             }
             ::VERSIONED_STRUCT_DATA_TYPE_TAG => {
-                let immut_data =
-                    ffi_try!(immut_data_operations::create(client.clone(), plain_text, None));
+                let immut_data = ffi_try!(immut_data_operations::create(client.clone(),
+                                                                        plain_text,
+                                                                        None));
                 // TODO The above data could be exactly 1 MiB and ideally should not be touched any
                 // more. For this however we will require CipherOpt to be in core module. Until
                 // that we need to live with this.
                 let ser_immut_data = ffi_try!(serialise(&immut_data).map_err(FfiError::from));
                 let raw_data = ffi_try!(ffi_try!(unwrap!(object_cache())
-                        .get_cipher_opt(cipher_opt_h))
-                    .encrypt(app, &ser_immut_data));
+                                                     .get_cipher_opt(cipher_opt_h))
+                                            .encrypt(app, &ser_immut_data));
 
                 let immut_data_final = Data::Immutable(ImmutableData::new(raw_data));
                 let immut_data_final_name = *immut_data_final.name();
@@ -97,8 +98,8 @@ pub unsafe extern "C" fn struct_data_new(app: *const App,
             }
             x if x >= CLIENT_STRUCTURED_DATA_TAG => {
                 let raw_data = ffi_try!(ffi_try!(unwrap!(object_cache())
-                        .get_cipher_opt(cipher_opt_h))
-                    .encrypt(app, &plain_text));
+                                                     .get_cipher_opt(cipher_opt_h))
+                                            .encrypt(app, &plain_text));
 
                 ffi_try!(StructuredData::new(type_tag,
                                              xor_id,
@@ -107,7 +108,7 @@ pub unsafe extern "C" fn struct_data_new(app: *const App,
                                              owner_keys,
                                              Vec::new(),
                                              Some(&sign_key))
-                    .map_err(CoreError::from))
+                             .map_err(CoreError::from))
             }
             _ => ffi_try!(Err(FfiError::InvalidStructuredDataTypeTag)),
         };
@@ -179,7 +180,7 @@ pub unsafe extern "C" fn struct_data_new_data(app: *const App,
         let new_sd = match ffi_try!(object_cache.get_sd(sd_h)).get_type_tag() {
             ::UNVERSIONED_STRUCT_DATA_TYPE_TAG => {
                 let raw_data = ffi_try!(ffi_try!(object_cache.get_cipher_opt(cipher_opt_h))
-                    .encrypt(app, &plain_text));
+                                            .encrypt(app, &plain_text));
 
                 let sd = ffi_try!(object_cache.get_sd(sd_h));
                 ffi_try!(unversioned::create(client,
@@ -194,11 +195,12 @@ pub unsafe extern "C" fn struct_data_new_data(app: *const App,
                                              None))
             }
             ::VERSIONED_STRUCT_DATA_TYPE_TAG => {
-                let immut_data =
-                    ffi_try!(immut_data_operations::create(client.clone(), plain_text, None));
+                let immut_data = ffi_try!(immut_data_operations::create(client.clone(),
+                                                                        plain_text,
+                                                                        None));
                 let ser_immut_data = ffi_try!(serialise(&immut_data).map_err(FfiError::from));
                 let raw_data = ffi_try!(ffi_try!(object_cache.get_cipher_opt(cipher_opt_h))
-                    .encrypt(app, &ser_immut_data));
+                                            .encrypt(app, &ser_immut_data));
 
                 let immut_data_final = Data::Immutable(ImmutableData::new(raw_data));
                 let immut_data_final_name = *immut_data_final.name();
@@ -214,7 +216,7 @@ pub unsafe extern "C" fn struct_data_new_data(app: *const App,
             }
             x if x >= CLIENT_STRUCTURED_DATA_TAG => {
                 let raw_data = ffi_try!(ffi_try!(object_cache.get_cipher_opt(cipher_opt_h))
-                    .encrypt(app, &plain_text));
+                                            .encrypt(app, &plain_text));
 
                 let sd = ffi_try!(object_cache.get_sd(sd_h));
                 ffi_try!(StructuredData::new(sd.get_type_tag(),
@@ -224,7 +226,7 @@ pub unsafe extern "C" fn struct_data_new_data(app: *const App,
                                              sd.get_owner_keys().clone(),
                                              sd.get_previous_owner_keys().clone(),
                                              Some(&sign_key))
-                    .map_err(CoreError::from))
+                             .map_err(CoreError::from))
             }
             _ => ffi_try!(Err(FfiError::InvalidStructuredDataTypeTag)),
         };
@@ -252,31 +254,27 @@ pub unsafe extern "C" fn struct_data_extract_data(app: *const App,
 
         let mut plain_text = match ffi_try!(obj_cache.get_sd(sd_h)).get_type_tag() {
             ::UNVERSIONED_STRUCT_DATA_TYPE_TAG => {
-                let raw_data =
-                    ffi_try!(unversioned::get_data(client, ffi_try!(obj_cache.get_sd(sd_h)), None));
+                let raw_data = ffi_try!(unversioned::get_data(client,
+                                                              ffi_try!(obj_cache.get_sd(sd_h)),
+                                                              None));
                 ffi_try!(CipherOpt::decrypt(&app, &raw_data))
             }
             ::VERSIONED_STRUCT_DATA_TYPE_TAG => {
-                let mut versions = ffi_try!(versioned::get_all_versions(client.clone(),
-                                                         ffi_try!(obj_cache.get_sd(sd_h))));
-                if let Some(immut_data_final_name) = versions.pop() {
-                    let resp_getter = ffi_try!(unwrap!(client.lock())
-                        .get(DataIdentifier::Immutable(immut_data_final_name), None));
-                    let immut_data_final = match ffi_try!(resp_getter.get()) {
-                        Data::Immutable(immut_data) => immut_data,
-                        _ => ffi_try!(Err(CoreError::ReceivedUnexpectedData)),
-                    };
+                let immut_data_final_name =
+                    ffi_try!(versioned::current_version(ffi_try!(obj_cache.get_sd(sd_h))));
 
-                    let ser_immut_data = ffi_try!(CipherOpt::decrypt(&app,
-                                                                     immut_data_final.value()));
-                    let immut_data = ffi_try!(deserialise::<ImmutableData>(&ser_immut_data)
-                        .map_err(FfiError::from));
-                    ffi_try!(immut_data_operations::get_data_from_immut_data(client,
-                                                                             immut_data,
-                                                                             None))
-                } else {
-                    Vec::new()
-                }
+                let resp_getter =
+                    ffi_try!(unwrap!(client.lock())
+                                 .get(DataIdentifier::Immutable(immut_data_final_name), None));
+                let immut_data_final = match ffi_try!(resp_getter.get()) {
+                    Data::Immutable(immut_data) => immut_data,
+                    _ => ffi_try!(Err(CoreError::ReceivedUnexpectedData)),
+                };
+
+                let ser_immut_data = ffi_try!(CipherOpt::decrypt(&app, immut_data_final.value()));
+                let immut_data = ffi_try!(deserialise::<ImmutableData>(&ser_immut_data)
+                                              .map_err(FfiError::from));
+                ffi_try!(immut_data_operations::get_data_from_immut_data(client, immut_data, None))
             }
             x if x >= CLIENT_STRUCTURED_DATA_TAG => {
                 ffi_try!(CipherOpt::decrypt(&app, ffi_try!(obj_cache.get_sd(sd_h)).get_data()))
@@ -295,23 +293,14 @@ pub unsafe extern "C" fn struct_data_extract_data(app: *const App,
 
 /// Get number of versions from a versioned StructuredData
 #[no_mangle]
-pub unsafe extern "C" fn struct_data_num_of_versions(app: *const App,
-                                                     sd_h: StructDataHandle,
+pub unsafe extern "C" fn struct_data_num_of_versions(sd_h: StructDataHandle,
                                                      o_num: *mut usize)
                                                      -> i32 {
     helper::catch_unwind_i32(|| {
         let mut obj_cache = unwrap!(object_cache());
         let sd = ffi_try!(obj_cache.get_sd(sd_h));
-
-        // TODO Move this check to core module itself (from all functions here using this pattern.
-        if sd.get_type_tag() != ::VERSIONED_STRUCT_DATA_TYPE_TAG {
-            ffi_try!(Err(FfiError::InvalidStructuredDataTypeTag));
-        }
-
-        let num = ffi_try!(versioned::get_all_versions((*app).get_client(), sd)).len();
-
-        ptr::write(o_num, num);
-
+        let num = ffi_try!(versioned::version_count(&sd).map_err(FfiError::from));
+        ptr::write(o_num, num as usize);
         0
     })
 }
@@ -347,7 +336,8 @@ pub unsafe extern "C" fn struct_data_nth_version(app: *const App,
         // TODO Try to combine this code with above (extract_data) if it makes it smaller
         let immut_data_final_name = versions.remove(n);
         let resp_getter = ffi_try!(unwrap!(client.lock())
-            .get(DataIdentifier::Immutable(immut_data_final_name), None));
+                                       .get(DataIdentifier::Immutable(immut_data_final_name),
+                                            None));
         let immut_data_final = match ffi_try!(resp_getter.get()) {
             Data::Immutable(immut_data) => immut_data,
             _ => ffi_try!(Err(CoreError::ReceivedUnexpectedData)),
@@ -355,9 +345,10 @@ pub unsafe extern "C" fn struct_data_nth_version(app: *const App,
 
         let ser_immut_data = ffi_try!(CipherOpt::decrypt(&app, immut_data_final.value()));
         let immut_data = ffi_try!(deserialise::<ImmutableData>(&ser_immut_data)
-            .map_err(FfiError::from));
-        let mut plain_text =
-            ffi_try!(immut_data_operations::get_data_from_immut_data(client, immut_data, None));
+                                      .map_err(FfiError::from));
+        let mut plain_text = ffi_try!(immut_data_operations::get_data_from_immut_data(client,
+                                                                                      immut_data,
+                                                                                      None));
 
         *o_data = plain_text.as_mut_ptr();
         ptr::write(o_size, plain_text.len());
@@ -410,7 +401,7 @@ fn struct_data_post_impl(client: Arc<Mutex<Client>>,
                                           sd.get_owner_keys().clone(),
                                           sd.get_previous_owner_keys().clone(),
                                           Some(&sign_key))
-        .map_err(CoreError::from));
+                          .map_err(CoreError::from));
 
     let data = Data::Structured(new_sd.clone());
     let resp_getter = try!(unwrap!(client.lock()).post(data, None));
@@ -447,13 +438,24 @@ fn struct_data_delete_impl(client: Arc<Mutex<Client>>,
                                           sd.get_owner_keys().clone(),
                                           sd.get_previous_owner_keys().clone(),
                                           Some(&sign_key))
-        .map_err(CoreError::from));
+                          .map_err(CoreError::from));
 
     let data = Data::Structured(new_sd.clone());
     let resp_getter = try!(unwrap!(client.lock()).delete(data, None));
     try!(resp_getter.get());
 
     Ok(new_sd)
+}
+
+/// Get the current version of StructuredData by its handle
+#[no_mangle]
+pub extern "C" fn struct_data_version(handle: StructDataHandle, o_version: *mut u64) -> i32 {
+    helper::catch_unwind_i32(|| {
+        unsafe {
+            *o_version = ffi_try!(unwrap!(object_cache()).get_sd(handle)).get_version();
+        }
+        0
+    })
 }
 
 /// Free StructuredData handle
@@ -542,7 +544,7 @@ mod tests {
 
             // Perform Invalid Operations - should error out
             let mut versions = 0;
-            assert_eq!(struct_data_num_of_versions(&app, sd_h, &mut versions),
+            assert_eq!(struct_data_num_of_versions(sd_h, &mut versions),
                        FfiError::InvalidStructuredDataTypeTag.into());
             {
                 let mut data_ptr: *mut u8 = ptr::null_mut();
@@ -603,10 +605,13 @@ mod tests {
 
             // Check content
             let mut num_versions = 0usize;
-            assert_eq!(struct_data_num_of_versions(&app, sd_h, &mut num_versions),
-                       0);
+            assert_eq!(struct_data_num_of_versions(sd_h, &mut num_versions), 0);
             assert_eq!(num_versions, 1);
             assert_eq!(nth_version(&app, sd_h, 0), data0);
+
+            let mut version = 0;
+            assert_eq!(struct_data_version(sd_h, &mut version), 0);
+            assert_eq!(version, 0);
 
             assert_eq!(extract_data(&app, sd_h), data0);
 
@@ -620,13 +625,16 @@ mod tests {
             assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
 
             // Check content
-            assert_eq!(struct_data_num_of_versions(&app, sd_h, &mut num_versions),
-                       0);
+            assert_eq!(struct_data_num_of_versions(sd_h, &mut num_versions), 0);
             assert_eq!(num_versions, 2);
             assert_eq!(nth_version(&app, sd_h, 0), data0);
             assert_eq!(nth_version(&app, sd_h, 1), data1);
 
             assert_eq!(extract_data(&app, sd_h), data1);
+
+            let mut version = 0;
+            assert_eq!(struct_data_version(sd_h, &mut version), 0);
+            assert_eq!(version, 1);
 
             // Delete
             assert_eq!(struct_data_delete(&app, sd_h), 0);
@@ -693,7 +701,7 @@ mod tests {
 
             // Invalid operations
             let mut num_versions = 0;
-            assert_eq!(struct_data_num_of_versions(&app, sd_h, &mut num_versions),
+            assert_eq!(struct_data_num_of_versions(sd_h, &mut num_versions),
                        FfiError::InvalidStructuredDataTypeTag.into());
 
             // Delete

--- a/src/ffi/nfs/dir.rs
+++ b/src/ffi/nfs/dir.rs
@@ -22,7 +22,7 @@ use ffi::directory_details::DirectoryDetails;
 use ffi::errors::FfiError;
 use ffi::helper;
 use libc::int32_t;
-use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG, VERSIONED_DIRECTORY_LISTING_TAG};
+use nfs::AccessLevel;
 use nfs::errors::NfsError;
 use nfs::helper::directory_helper::DirectoryHelper;
 use std::slice;
@@ -164,14 +164,7 @@ fn create_dir(app: &App,
         AccessLevel::Public
     };
 
-    let tag = if is_versioned {
-        VERSIONED_DIRECTORY_LISTING_TAG
-    } else {
-        UNVERSIONED_DIRECTORY_LISTING_TAG
-    };
-
     let _ = try!(dir_helper.create(dir_to_create,
-                                   tag,
                                    user_metadata.to_owned(),
                                    is_versioned,
                                    access_level,
@@ -257,9 +250,6 @@ fn move_dir(app: &App,
         let created_time = *src_dir.get_metadata().get_created_time();
         let modified_time = *src_dir.get_metadata().get_modified_time();
         let (mut dir, _) = try!(directory_helper.create(name,
-                                                        src_dir.get_metadata()
-                                                            .get_key()
-                                                            .get_type_tag(),
                                                         user_metadata,
                                                         src_dir.get_metadata()
                                                             .get_key()
@@ -299,7 +289,7 @@ fn move_dir(app: &App,
 mod test {
     use ffi::app::App;
     use ffi::test_utils;
-    use nfs::{AccessLevel, UNVERSIONED_DIRECTORY_LISTING_TAG};
+    use nfs::AccessLevel;
     use nfs::helper::directory_helper::DirectoryHelper;
     use std::slice;
 
@@ -308,7 +298,6 @@ mod test {
         let dir_helper = DirectoryHelper::new(app.get_client());
         let mut app_root_dir = unwrap!(dir_helper.get(&app_dir_key));
         let _ = unwrap!(dir_helper.create(name.to_string(),
-                                          UNVERSIONED_DIRECTORY_LISTING_TAG,
                                           Vec::new(),
                                           false,
                                           AccessLevel::Private,

--- a/src/nfs/directory_listing.rs
+++ b/src/nfs/directory_listing.rs
@@ -41,14 +41,12 @@ pub struct DirectoryListing {
 impl DirectoryListing {
     /// Create a new DirectoryListing
     pub fn new(name: String,
-               tag_type: u64,
                user_metadata: Vec<u8>,
                versioned: bool,
                access_level: AccessLevel,
                parent_dir_key: Option<DirectoryKey>)
                -> Result<DirectoryListing, NfsError> {
         let meta_data = try!(DirectoryMetadata::new(name,
-                                                    tag_type,
                                                     versioned,
                                                     access_level,
                                                     user_metadata,
@@ -230,7 +228,6 @@ mod test {
     #[test]
     fn serialise_and_deserialise_directory_listing() {
         let obj_before = unwrap!(DirectoryListing::new("Home".to_string(),
-                                                       10,
                                                        "some metadata about the directory"
                                                            .to_string()
                                                            .into_bytes(),
@@ -248,7 +245,6 @@ mod test {
         let test_client = unwrap!(test_utils::get_client());
         let client = Arc::new(Mutex::new(test_client));
         let directory_listing = unwrap!(DirectoryListing::new("Home".to_string(),
-                                                              10,
                                                               Vec::new(),
                                                               true,
                                                               AccessLevel::Private,
@@ -264,7 +260,6 @@ mod test {
     #[test]
     fn find_upsert_remove_file() {
         let mut directory_listing = unwrap!(DirectoryListing::new("Home".to_string(),
-                                                                  10,
                                                                   Vec::new(),
                                                                   true,
                                                                   AccessLevel::Private,
@@ -300,13 +295,11 @@ mod test {
     #[test]
     fn find_upsert_remove_directory() {
         let mut directory_listing = unwrap!(DirectoryListing::new("Home".to_string(),
-                                                                  10,
                                                                   Vec::new(),
                                                                   true,
                                                                   AccessLevel::Private,
                                                                   None));
         let mut sub_directory = unwrap!(DirectoryListing::new("Child one".to_string(),
-                                                              10,
                                                               Vec::new(),
                                                               true,
                                                               AccessLevel::Private,
@@ -321,7 +314,6 @@ mod test {
         directory_listing.upsert_sub_directory(sub_directory.get_metadata().clone());
         assert_eq!(directory_listing.get_sub_directories().len(), 1);
         let sub_directory_two = unwrap!(DirectoryListing::new("Child Two".to_string(),
-                                                              10,
                                                               Vec::new(),
                                                               true,
                                                               AccessLevel::Private,

--- a/src/nfs/helper/directory_helper.rs
+++ b/src/nfs/helper/directory_helper.rs
@@ -46,7 +46,6 @@ impl DirectoryHelper {
     /// Returns (created_directory, Option<parent_directory's parent>)
     pub fn create(&self,
                   directory_name: String,
-                  tag_type: u64,
                   user_metadata: Vec<u8>,
                   versioned: bool,
                   access_level: AccessLevel,
@@ -65,7 +64,6 @@ impl DirectoryHelper {
 
         let directory =
             try!(DirectoryListing::new(directory_name,
-                                       tag_type,
                                        user_metadata,
                                        versioned,
                                        access_level,
@@ -197,7 +195,6 @@ impl DirectoryHelper {
         match root_directory_id {
             Some(id) => {
                 self.get(&DirectoryKey::new(id,
-                                            ::nfs::UNVERSIONED_DIRECTORY_LISTING_TAG,
                                             false,
                                             AccessLevel::Private))
             }
@@ -206,7 +203,6 @@ impl DirectoryHelper {
 
                 let (created_directory, _) =
                     try!(self.create(::nfs::ROOT_DIRECTORY_NAME.to_string(),
-                                     ::nfs::UNVERSIONED_DIRECTORY_LISTING_TAG,
                                      Vec::new(),
                                      false,
                                      AccessLevel::Private,
@@ -233,7 +229,6 @@ impl DirectoryHelper {
         let mut config_directory_listing = match config_dir_id {
             Some(id) => {
                 try!(self.get(&DirectoryKey::new(id,
-                                                 ::nfs::UNVERSIONED_DIRECTORY_LISTING_TAG,
                                                  false,
                                                  AccessLevel::Private)))
             }
@@ -242,7 +237,6 @@ impl DirectoryHelper {
 
                 let (created_directory, _) =
                     try!(self.create(::nfs::CONFIGURATION_DIRECTORY_NAME.to_string(),
-                                     ::nfs::UNVERSIONED_DIRECTORY_LISTING_TAG,
                                      Vec::new(),
                                      false,
                                      AccessLevel::Private,
@@ -266,7 +260,6 @@ impl DirectoryHelper {
                         configuration dir) - creating one.");
 
                 let (directory, _) = try!(self.create(directory_name,
-                                                      ::nfs::UNVERSIONED_DIRECTORY_LISTING_TAG,
                                                       Vec::new(),
                                                       false,
                                                       AccessLevel::Private,
@@ -425,7 +418,6 @@ mod test {
         let dir_helper = DirectoryHelper::new(client.clone());
         // Create a Directory
         let (mut directory, grand_parent) = unwrap!(dir_helper.create("DirName".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,
@@ -434,7 +426,6 @@ mod test {
         assert_eq!(directory, unwrap!(dir_helper.get(directory.get_key())));
         // Create a Child directory and update the parent_directory
         let (mut child_directory, grand_parent) = unwrap!(dir_helper.create("Child".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,
@@ -446,13 +437,11 @@ mod test {
 
         let (grand_child_directory, grand_parent) =
             unwrap!(dir_helper.create("Grand Child".to_string(),
-                                      ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                                       Vec::new(),
                                       true,
                                       AccessLevel::Private,
                                       Some(&mut child_directory)));
         assert!(dir_helper.create("Grand Child".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,
@@ -474,7 +463,6 @@ mod test {
             let client = Arc::new(Mutex::new(test_client));
             let dir_helper = DirectoryHelper::new(client.clone());
             let (directory, _) = unwrap!(dir_helper.create("PublicDirectory".to_string(),
-                        ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                         vec![2u8, 10],
                         true,
                         AccessLevel::Public,
@@ -498,7 +486,6 @@ mod test {
             let client = Arc::new(Mutex::new(test_client));
             let dir_helper = DirectoryHelper::new(client.clone());
             let (directory, _) = unwrap!(dir_helper.create("PublicDirectory".to_string(),
-                        ::nfs::UNVERSIONED_DIRECTORY_LISTING_TAG,
                         vec![2u8, 10],
                         false,
                         AccessLevel::Public,
@@ -522,7 +509,6 @@ mod test {
 
         let mut root_dir = unwrap!(dir_helper.get_user_root_directory_listing());
         let (created_dir, _) = unwrap!(dir_helper.create("DirName".to_string(),
-                                                         ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                                                          Vec::new(),
                                                          true,
                                                          AccessLevel::Private,
@@ -551,7 +537,6 @@ mod test {
         let dir_helper = DirectoryHelper::new(client.clone());
 
         let (mut dir_listing, _) = unwrap!(dir_helper.create("DirName2".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,
@@ -590,7 +575,6 @@ mod test {
         let dir_helper = DirectoryHelper::new(client.clone());
         // Create a Directory
         let (mut directory, grand_parent) = unwrap!(dir_helper.create("DirName".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,
@@ -599,7 +583,6 @@ mod test {
         assert_eq!(directory, unwrap!(dir_helper.get(directory.get_key())));
         // Create a Child directory and update the parent_directory
         let (mut child_directory, grand_parent) = unwrap!(dir_helper.create("Child".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,
@@ -611,7 +594,6 @@ mod test {
 
         let (grand_child_directory, grand_parent) =
             unwrap!(dir_helper.create("Grand Child".to_string(),
-                                      ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                                       Vec::new(),
                                       true,
                                       AccessLevel::Private,

--- a/src/nfs/helper/file_helper.rs
+++ b/src/nfs/helper/file_helper.rs
@@ -190,7 +190,6 @@ mod test {
         let client = get_client();
         let dir_helper = DirectoryHelper::new(client.clone());
         let (mut directory, _) = unwrap!(dir_helper.create("DirName".to_string(),
-                    ::nfs::VERSIONED_DIRECTORY_LISTING_TAG,
                     Vec::new(),
                     true,
                     AccessLevel::Private,

--- a/src/nfs/metadata/directory_metadata.rs
+++ b/src/nfs/metadata/directory_metadata.rs
@@ -36,7 +36,6 @@ pub struct DirectoryMetadata {
 impl DirectoryMetadata {
     /// Create a new instance of Metadata
     pub fn new(name: String,
-               type_tag: u64,
                versioned: bool,
                access_level: AccessLevel,
                user_metadata: Vec<u8>,
@@ -44,7 +43,7 @@ impl DirectoryMetadata {
                -> Result<DirectoryMetadata, NfsError> {
         let id = Rand::rand(&mut unwrap!(OsRng::new(), "Failed to create OsRng."));
         Ok(DirectoryMetadata {
-            key: DirectoryKey::new(id, type_tag, versioned, access_level),
+            key: DirectoryKey::new(id, versioned, access_level),
             name: name,
             created_time: ::time::now_utc(),
             modified_time: ::time::now_utc(),
@@ -184,7 +183,6 @@ mod test {
     #[test]
     fn serialise_directory_metadata_without_parent_directory() {
         let obj_before = unwrap!(DirectoryMetadata::new("hello.txt".to_string(),
-                                                        99u64,
                                                         true,
                                                         AccessLevel::Private,
                                                         Vec::new(),
@@ -197,9 +195,8 @@ mod test {
     #[test]
     fn serialise_directory_metadata_with_parent_directory() {
         let id: XorName = rand::random();
-        let parent_directory = DirectoryKey::new(id, 100u64, false, AccessLevel::Private);
+        let parent_directory = DirectoryKey::new(id, false, AccessLevel::Private);
         let obj_before = unwrap!(DirectoryMetadata::new("hello.txt".to_string(),
-                                                        99u64,
                                                         true,
                                                         AccessLevel::Private,
                                                         "Some user metadata"
@@ -218,12 +215,10 @@ mod test {
         let id: XorName = rand::random();
         let modified_time = ::time::now_utc();
         let mut obj_before = unwrap!(DirectoryMetadata::new("hello.txt".to_string(),
-                                                  99u64,
                                                   true,
                                                   AccessLevel::Private,
                                                   Vec::new(),
                                                   Some(DirectoryKey::new(id,
-                                                                         100u64,
                                                                          false,
                                                                          AccessLevel::Private))));
         let user_metadata = "{mime: \"application/json\"}".to_string().into_bytes();


### PR DESCRIPTION
In addition, this patch optimises versions storage in versioned StructuredData. Now it stores the current version and total versions count along with a XorName of the versions list.