### PR TITLE
fix/ffi: add missing no_mangle on an FFI function

### DIFF
--- a/src/ffi/low_level_api/misc.rs
+++ b/src/ffi/low_level_api/misc.rs
@@ -64,6 +64,7 @@ pub unsafe extern "C" fn misc_serialise_sign_key(sign_key_h: SignKeyHandle,
 }
 
 /// Deserialise sign::PubKey
+#[no_mangle]
 pub unsafe extern "C" fn misc_deserialise_sign_key(data: *mut u8,
                                                    size: usize,
                                                    o_handle: *mut SignKeyHandle)


### PR DESCRIPTION
misc_deserialise_sign_key name is missing #[no_mangle]