### PR TITLE
refactor/core: make ok! and err! macros use boxed values

### DIFF
--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -120,7 +120,8 @@ impl Client {
             Ok(Event::Response { response: Response::PutFailure { id,
                                                         data_id,
                                                         ref external_error_indicator },
-                                 .. }) if id == msg_id => {
+                                 .. })
+                if id == msg_id => {
                 return Err(CoreError::MutationFailure {
                     data_id: data_id,
                     reason: routing_el::parse_mutation_err(external_error_indicator),
@@ -178,7 +179,8 @@ impl Client {
                 }
                 Ok(Event::Response {
                     response: Response::GetFailure { id, data_id, ref external_error_indicator }, ..
-                }) if id == msg_id => {
+                })
+                    if id == msg_id => {
                     return Err(CoreError::GetFailure {
                         data_id: data_id,
                         reason: routing_el::parse_get_err(external_error_indicator),
@@ -231,10 +233,12 @@ impl Client {
 
         let (head, oneshot) = futures::oneshot();
         let rx = oneshot.map_err(|_| CoreError::OperationAborted)
-            .and_then(|event| match event {
-                CoreEvent::Get(res) => res,
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            });
+                        .and_then(|event| {
+                            match event {
+                                CoreEvent::Get(res) => res,
+                                _ => Err(CoreError::ReceivedUnexpectedEvent),
+                            }
+                        });
 
         let rx = if let DataIdentifier::Immutable(..) = data_id {
             if let Some(data) = self.cache.borrow_mut().get_mut(data_id.name()) {
@@ -245,14 +249,15 @@ impl Client {
 
             let cache = self.cache.clone();
             rx.map(move |data| {
-                match data {
-                    ref data @ Data::Immutable(_) => {
-                        let _ = cache.borrow_mut().insert(*data.name(), data.clone());
-                    }
-                    _ => (),
-                }
-                data
-            }).into_box()
+                  match data {
+                      ref data @ Data::Immutable(_) => {
+                          let _ = cache.borrow_mut().insert(*data.name(), data.clone());
+                      }
+                      _ => (),
+                  }
+                  data
+              })
+              .into_box()
         } else {
             rx.into_box()
         };
@@ -386,10 +391,13 @@ impl Client {
 
         let (head, oneshot) = futures::oneshot();
         let rx = oneshot.map_err(|_| CoreError::OperationAborted)
-            .and_then(|event| match event {
-                CoreEvent::AccountInfo(res) => res,
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            }).into_box();
+                        .and_then(|event| {
+                            match event {
+                                CoreEvent::AccountInfo(res) => res,
+                                _ => Err(CoreError::ReceivedUnexpectedEvent),
+                            }
+                        })
+                        .into_box();
 
         let dst = match dst {
             Some(auth) => auth,
@@ -419,7 +427,9 @@ impl Client {
     /// store it. It will be retrieved when the user logs into their account. Root directory ID is
     /// necessary to fetch all of the user's data as all further data is encoded as meta-information
     /// into the Root Directory or one of its subdirectories.
-    pub fn set_user_root_dir_id(&mut self, dir_id: (XorName, secretbox::Key)) -> Box<ReturnType<()>> {
+    pub fn set_user_root_dir_id(&mut self,
+                                dir_id: (XorName, secretbox::Key))
+                                -> Box<ReturnType<()>> {
         trace!("Setting user root Dir ID.");
 
         let set = {
@@ -430,7 +440,7 @@ impl Client {
         if set {
             self.update_session_packet()
         } else {
-            err!(CoreError::RootDirectoryAlreadyExists).into_box()
+            err!(CoreError::RootDirectoryAlreadyExists)
         }
     }
 
@@ -444,7 +454,9 @@ impl Client {
     /// their account. Root directory ID is necessary to fetch all of configuration data as all
     /// further data is encoded as meta-information into the config Root Directory or one of its
     /// subdirectories.
-    pub fn set_config_root_dir_id(&mut self, dir_id: (XorName, secretbox::Key)) -> Box<ReturnType<()>> {
+    pub fn set_config_root_dir_id(&mut self,
+                                  dir_id: (XorName, secretbox::Key))
+                                  -> Box<ReturnType<()>> {
         trace!("Setting configuration root Dir ID.");
 
         let set = {
@@ -455,7 +467,7 @@ impl Client {
         if set {
             self.update_session_packet()
         } else {
-            err!(CoreError::RootDirectoryAlreadyExists).into_box()
+            err!(CoreError::RootDirectoryAlreadyExists)
         }
     }
 
@@ -526,7 +538,7 @@ impl Client {
 
     fn update_session_packet(&mut self) -> Box<ReturnType<()>> {
         // TODO (adam): implement this
-        ok!(()).into_box()
+        ok!(())
     }
 }
 
@@ -648,10 +660,14 @@ fn spawn_routing_thread(routing_rx: Receiver<Event>, core_tx: CoreMsgTx) -> Join
 }
 
 fn build_mutation_future(oneshot: Oneshot<CoreEvent>) -> Box<ReturnType<()>> {
-    oneshot.map_err(|_| CoreError::OperationAborted).and_then(|event| match event {
-        CoreEvent::Mutation(res) => res,
-        _ => Err(CoreError::ReceivedUnexpectedEvent),
-    }).into_box()
+    oneshot.map_err(|_| CoreError::OperationAborted)
+           .and_then(|event| {
+               match event {
+                   CoreEvent::Mutation(res) => res,
+                   _ => Err(CoreError::ReceivedUnexpectedEvent),
+               }
+           })
+           .into_box()
 }
 
 #[cfg(test)]
@@ -686,9 +702,10 @@ mod tests {
             let orig_data = orig_data.clone();
 
             unwrap!(core_tx.send(CoreMsg::new(move |cptr| {
-                let future = cptr.borrow_mut().put(orig_data, None)
-                                              .then(|_| Ok(()))
-                                              .into_box();
+                let future = cptr.borrow_mut()
+                                 .put(orig_data, None)
+                                 .then(|_| Ok(()))
+                                 .into_box();
                 Some(future)
             })));
 
@@ -707,35 +724,45 @@ mod tests {
             let cptr2 = cptr.clone();
             let cptr3 = cptr.clone();
 
-            let future = cptr.borrow_mut().get(data_id, None).map(move |data| {
-                assert_eq!(data, orig_data);
-            }).and_then(move |_| {
-                let name = rand::random();
-                let key  = secretbox::gen_key();
+            let future = cptr.borrow_mut()
+                             .get(data_id, None)
+                             .map(move |data| {
+                                 assert_eq!(data, orig_data);
+                             })
+                             .and_then(move |_| {
+                                 let name = rand::random();
+                                 let key = secretbox::gen_key();
 
-                let mut cptr = cptr2.borrow_mut();
-                cptr.set_user_root_dir_id((name, key))
-            }).map(|_| {
-                panic!("Unregistered client should not be allowed to set user root dir");
-            }).or_else(move |err| {
-                match err {
-                    CoreError::OperationForbiddenForClient => (),
-                    _ => panic!("Unexpected {:?}", err),
-                }
+                                 let mut cptr = cptr2.borrow_mut();
+                                 cptr.set_user_root_dir_id((name, key))
+                             })
+                             .map(|_| {
+                                 panic!("Unregistered client should not be allowed to set user \
+                                         root dir");
+                             })
+                             .or_else(move |err| {
+                                 match err {
+                                     CoreError::OperationForbiddenForClient => (),
+                                     _ => panic!("Unexpected {:?}", err),
+                                 }
 
-                let name = rand::random();
-                let key  = secretbox::gen_key();
+                                 let name = rand::random();
+                                 let key = secretbox::gen_key();
 
-                let mut cptr = cptr3.borrow_mut();
-                cptr.set_config_root_dir_id((name, key))
-            }).map(|_| {
-                panic!("Unregistered client should not be allowed to set config root dir");
-            }).map_err(|err| {
-                match err {
-                    CoreError::OperationForbiddenForClient => (),
-                    _ => panic!("Unexpected {:?}", err),
-                }
-            }).into_box();
+                                 let mut cptr = cptr3.borrow_mut();
+                                 cptr.set_config_root_dir_id((name, key))
+                             })
+                             .map(|_| {
+                                 panic!("Unregistered client should not be allowed to set config \
+                                         root dir");
+                             })
+                             .map_err(|err| {
+                                 match err {
+                                     CoreError::OperationForbiddenForClient => (),
+                                     _ => panic!("Unexpected {:?}", err),
+                                 }
+                             })
+                             .into_box();
 
             Some(future)
         })));

--- a/src/core/futures.rs
+++ b/src/core/futures.rs
@@ -43,7 +43,7 @@ macro_rules! ok {
 /// construct the return type equivalent of `Result::Err` in futures paradigm.
 macro_rules! err {
     ($elt:expr) => {
-        futures::done(Err($elt)).into_box()
+        futures::done(Err(From::from($elt))).into_box()
     }
 }
 

--- a/src/core/futures.rs
+++ b/src/core/futures.rs
@@ -35,7 +35,7 @@ macro_rules! fry {
 /// construct the return type equivalent of `Result::Ok` in futures paradigm.
 macro_rules! ok {
     ($elt:expr) => {
-        futures::done(Ok($elt))
+        futures::done(Ok($elt)).into_box()
     }
 }
 
@@ -43,7 +43,7 @@ macro_rules! ok {
 /// construct the return type equivalent of `Result::Err` in futures paradigm.
 macro_rules! err {
     ($elt:expr) => {
-        futures::done(Err($elt))
+        futures::done(Err($elt)).into_box()
     }
 }
 
@@ -51,11 +51,11 @@ macro_rules! err {
 pub trait FutureExt: Future + Sized {
     /// Box this future. Similar to `boxed` combinator, but does not require
     /// the future to implement `Send`.
-    fn into_box(self) -> Box<Future<Item=Self::Item, Error=Self::Error>>;
+    fn into_box(self) -> Box<Future<Item = Self::Item, Error = Self::Error>>;
 }
 
 impl<F: Future + 'static> FutureExt for F {
-    fn into_box(self) -> Box<Future<Item=Self::Item, Error=Self::Error>> {
+    fn into_box(self) -> Box<Future<Item = Self::Item, Error = Self::Error>> {
         Box::new(self)
     }
 }


### PR DESCRIPTION
With the added bonus of formatting altered by rustfmt