### PR TITLE
fix/nfs: make dir_helper::create private (MAID-1624)

### DIFF
--- a/src/ffi/launcher_config.rs
+++ b/src/ffi/launcher_config.rs
@@ -59,10 +59,11 @@ pub fn app(client: &Client,
                     dir_helper::user_root_dir(c2.clone())
                         .and_then(move |(root_dir, dir_id)| {
                             let app_dir_name = app_dir_name(&app_name, &root_dir);
+                            let key = Some(secretbox::gen_key());
 
                             dir_helper::create_sub_dir(client.clone(),
                                                        app_dir_name,
-                                                       None,
+                                                       key,
                                                        Vec::new(),
                                                        &root_dir,
                                                        &dir_id)

--- a/src/ffi/low_level_api/appendable_data.rs
+++ b/src/ffi/low_level_api/appendable_data.rs
@@ -1151,8 +1151,7 @@ pub unsafe extern "C" fn appendable_data_free(session: *const Session,
 }
 
 // Convenience function to access n-th item from the given set, returning
-// FfiError::InvalidIndex
-// if not found.
+// FfiError::InvalidIndex if not found.
 fn nth<T>(items: &BTreeSet<T>, n: usize) -> Result<&T, FfiError> {
     items.iter().nth(n).ok_or(FfiError::InvalidIndex)
 }

--- a/src/nfs/mod.rs
+++ b/src/nfs/mod.rs
@@ -36,21 +36,5 @@ pub use nfs::errors::NfsError;
 pub use nfs::file::File;
 pub use nfs::metadata::{DirMetadata, FileMetadata};
 
-/// Configuration directory Name stored in the session packet
-pub const CONFIGURATION_DIRECTORY_NAME: &'static str = "CONFIGURATION_ROOT";
-/// Root directory name
-pub const ROOT_DIRECTORY_NAME: &'static str = "USER_ROOT";
-
-/// AccessLevel indicates whether the container is Private or Public shared
-#[derive(RustcEncodable, RustcDecodable, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
-pub enum AccessLevel {
-    /// Private Directory where the directory is encrypted with users private
-    /// keys
-    Private,
-    /// Public Directory where the directory is not encrypted and anyone can
-    /// read the contents of it
-    Public,
-}
-
 /// Helper type for futures that can result in NfsError
 pub type NfsFuture<T> = Future<Item = T, Error = NfsError>;


### PR DESCRIPTION
* Make create, shallow_copy, and deep_copy functions private in
  dir_helper.
* Move move_dir function from FFI to NFS.
* Fix keys generation for private dirs in NFS.
* Refactor tests code in FFI