### PR TITLE
Low level API for StructData

### DIFF
--- a/src/core/structured_data/mod.rs
+++ b/src/core/structured_data/mod.rs
@@ -109,6 +109,36 @@ pub fn get(client: &Client, type_tag: u64, id: &XorName) -> Box<CoreFuture<Struc
         .into_box()
 }
 
+/// Delete structured data from the network.
+pub fn delete(client: &Client,
+              data: StructuredData,
+              signing_key: &sign::SecretKey)
+              -> Box<CoreFuture<()>> {
+    let data = fry!(create_for_deletion(data, signing_key));
+    client.delete(Data::Structured(data), None)
+}
+
+/// Delete structured data from the network, with recovery
+pub fn delete_recover(client: &Client,
+                      data: StructuredData,
+                      signing_key: &sign::SecretKey)
+                      -> Box<CoreFuture<()>> {
+    let data = fry!(create_for_deletion(data, signing_key));
+    client.delete_recover(Data::Structured(data), None)
+}
+
+fn create_for_deletion(data: StructuredData,
+                       signing_key: &sign::SecretKey)
+                       -> Result<StructuredData, CoreError> {
+    Ok(try!(StructuredData::new(data.get_type_tag(),
+                                *data.name(),
+                                data.get_version() + 1,
+                                vec![],
+                                vec![],
+                                data.get_owner_keys().clone(),
+                                Some(signing_key))))
+}
+
 #[cfg(test)]
 mod tests {
     use core::utility::test_utils;

--- a/src/core/structured_data/unversioned.rs
+++ b/src/core/structured_data/unversioned.rs
@@ -107,25 +107,6 @@ pub fn update(client: &Client,
         .into_box()
 }
 
-/// Delete structured data from the network.
-pub fn delete(client: &Client,
-              data: StructuredData,
-              signing_key: &sign::SecretKey)
-              -> Box<CoreFuture<()>> {
-    let data = fry!(create_for_deletion(data, signing_key));
-    client.delete(Data::Structured(data), None)
-}
-
-/// Delete structured data from the network, with recovery
-pub fn delete_recover(client: &Client,
-                      data: StructuredData,
-                      signing_key: &sign::SecretKey)
-                      -> Box<CoreFuture<()>> {
-    let data = fry!(create_for_deletion(data, signing_key));
-    client.delete_recover(Data::Structured(data), None)
-}
-
-
 /// Get the raw bytes from StructuredData created via `create()` function in
 /// this module.
 pub fn extract_value(client: &Client,
@@ -276,18 +257,6 @@ fn create_with_immutable_data(client: Client,
             }
         })
         .into_box()
-}
-
-fn create_for_deletion(data: StructuredData,
-                       signing_key: &sign::SecretKey)
-                       -> Result<StructuredData, CoreError> {
-    Ok(try!(StructuredData::new(data.get_type_tag(),
-                                *data.name(),
-                                data.get_version() + 1,
-                                vec![],
-                                vec![],
-                                data.get_owner_keys().clone(),
-                                Some(signing_key))))
 }
 
 fn encode(data: DataTypeEncoding,

--- a/src/dns/config.rs
+++ b/src/dns/config.rs
@@ -86,7 +86,8 @@ pub fn write(client: &Client, config: Vec<DnsConfig>) -> Box<DnsFuture<()>> {
                                     DNS_CONFIG_FILE_NAME.to_string(),
                                     vec![],
                                     dir_metadata.id(),
-                                    dir)
+                                    dir,
+                                    false)
             }
         })
         .and_then(move |writer| writer.write(&encoded_config).map(move |_| writer))

--- a/src/dns/operations.rs
+++ b/src/dns/operations.rs
@@ -135,7 +135,7 @@ pub fn delete_dns<S>(client: &Client, long_name: S, sign_sk: sign::SecretKey) ->
         .and_then(move |(saved_configs, pos, long_name)| {
             get_housing_structured_data(&client2, &long_name)
                 .and_then(move |struct_data| {
-                    unversioned::delete_recover(&client2, struct_data, &sign_sk)
+                    structured_data::delete_recover(&client2, struct_data, &sign_sk)
                         .map_err(DnsError::from)
                 })
                 .or_else(|err| match err {

--- a/src/ffi/dns/file.rs
+++ b/src/ffi/dns/file.rs
@@ -222,7 +222,7 @@ mod tests {
                                error: int32_t,
                                _file_details_ptr: *mut FileDetails) {
             assert_eq!(error, 0);
-            unsafe { test_utils::send_via_user_data(user_data) }
+            unsafe { test_utils::send_via_user_data(user_data, ()) }
         }
 
         unsafe {

--- a/src/ffi/dns/file.rs
+++ b/src/ffi/dns/file.rs
@@ -159,7 +159,7 @@ mod tests {
                 })
                 .then(move |result| {
                     let (_parent, dir, dir_meta) = unwrap!(result);
-                    file_helper::create(c3, file_name, Vec::new(), dir_meta.id(), dir)
+                    file_helper::create(c3, file_name, Vec::new(), dir_meta.id(), dir, false)
                         .map(move |writer| (writer, dir_meta.id()))
                 })
                 .then(move |result| {

--- a/src/ffi/dns/long_name.rs
+++ b/src/ffi/dns/long_name.rs
@@ -144,7 +144,7 @@ mod tests {
         let long_name = unwrap!(utility::generate_random_string(10));
         let long_name = test_utils::as_raw_parts(&long_name);
 
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::channel::<()>();
 
         // Register
         {
@@ -152,7 +152,7 @@ mod tests {
 
             extern "C" fn register_cb(user_data: *mut c_void, error: int32_t) {
                 assert_eq!(error, 0);
-                unsafe { test_utils::send_via_user_data(user_data) }
+                unsafe { test_utils::send_via_user_data(user_data, ()) }
             }
 
             extern "C" fn get_cb(user_data: *mut c_void, error: int32_t, list: *mut StringList) {
@@ -161,7 +161,7 @@ mod tests {
                 unsafe {
                     assert_eq!(string_list_len(list), 1);
                     string_list_free(list);
-                    test_utils::send_via_user_data(user_data)
+                    test_utils::send_via_user_data(user_data, ())
                 }
             }
 
@@ -188,7 +188,7 @@ mod tests {
 
             extern "C" fn callback(user_data: *mut c_void, error: int32_t) {
                 assert_eq!(error, DnsError::DnsNameAlreadyRegistered.into());
-                unsafe { test_utils::send_via_user_data(user_data) }
+                unsafe { test_utils::send_via_user_data(user_data, ()) }
             }
 
             unsafe {

--- a/src/ffi/dns/service.rs
+++ b/src/ffi/dns/service.rs
@@ -209,7 +209,6 @@ pub unsafe extern "C" fn dns_get_service_dir(session: *const Session,
                             move |error| o_cb(user_data, error, ptr::null_mut()))
 }
 
-
 #[cfg(test)]
 mod tests {
     use core::{Client, utility};
@@ -248,7 +247,7 @@ mod tests {
             object_cache.insert_app(app)
         };
 
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::channel::<()>();
 
         let long_name = test_utils::as_raw_parts(&long_name2);
         let service_name = test_utils::as_raw_parts("www");
@@ -256,7 +255,7 @@ mod tests {
 
         extern "C" fn callback(user_data: *mut c_void, error: int32_t) {
             assert_eq!(error, 0);
-            unsafe { test_utils::send_via_user_data(user_data) }
+            unsafe { test_utils::send_via_user_data(user_data, ()) }
         }
 
         unsafe {
@@ -297,7 +296,7 @@ mod tests {
 
         let session2 = test_utils::create_unregistered_session();
 
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::channel::<()>();
 
         let long_name = test_utils::as_raw_parts(&long_name2);
         let service_name = test_utils::as_raw_parts("www");
@@ -307,7 +306,7 @@ mod tests {
                                dir_details: *mut DirDetails) {
             assert_eq!(error, 0);
             assert!(!dir_details.is_null());
-            unsafe { test_utils::send_via_user_data(user_data) }
+            unsafe { test_utils::send_via_user_data(user_data, ()) }
         }
 
         unsafe {

--- a/src/ffi/errors.rs
+++ b/src/ffi/errors.rs
@@ -61,6 +61,8 @@ pub enum FfiError {
     /// Could not convert String to nul-terminated string because it contains
     /// internal nuls.
     NulError(NulError),
+    /// Invalid App handle
+    InvalidAppHandle,
     /// Invalid StructuredData handle
     InvalidStructDataHandle,
     /// Invalid DataIdentifier handle
@@ -162,6 +164,7 @@ impl Into<i32> for FfiError {
             FfiError::Unexpected(_) => FFI_ERROR_START_RANGE - 9,
             FfiError::UnsuccessfulEncodeDecode(_) => FFI_ERROR_START_RANGE - 10,
             FfiError::NulError(_) => FFI_ERROR_START_RANGE - 11,
+            FfiError::InvalidAppHandle => FFI_ERROR_START_RANGE - 26,
             FfiError::InvalidStructDataHandle => FFI_ERROR_START_RANGE - 12,
             FfiError::InvalidDataIdHandle => FFI_ERROR_START_RANGE - 13,
             FfiError::InvalidAppendableDataHandle => FFI_ERROR_START_RANGE - 14,
@@ -197,6 +200,7 @@ impl fmt::Debug for FfiError {
                 write!(f, "FfiError::UnsuccessfulEncodeDecode -> {:?}", error)
             }
             FfiError::NulError(ref error) => write!(f, "FfiError::NulError -> {:?}", error),
+            FfiError::InvalidAppHandle => write!(f, "FfiError::InvalidAppHandle"),
             FfiError::InvalidStructDataHandle => write!(f, "FfiError::InvalidStructDataHandle"),
             FfiError::InvalidDataIdHandle => write!(f, "FfiError::InvalidDataIdHandle"),
             FfiError::InvalidAppendableDataHandle => {

--- a/src/ffi/errors.rs
+++ b/src/ffi/errors.rs
@@ -87,10 +87,10 @@ pub enum FfiError {
     InvalidSelfEncryptorReadOffsets,
     /// Invalid indexing
     InvalidIndex,
-    /// Unsupported Operation (e.g. mixing Pub/PrivAppendableData operations
+    /// Unsupported Operation (e.g. mixing Pub/PrivAppendableData operations)
     UnsupportedOperation,
     /// Input/output Error
-    IoError(::std::io::Error),
+    IoError(IoError),
 }
 
 impl From<SerialisationError> for FfiError {

--- a/src/ffi/errors.rs
+++ b/src/ffi/errors.rs
@@ -79,8 +79,6 @@ pub enum FfiError {
     InvalidSignKeyHandle,
     /// The requested operation is forbidded for the given app.
     OperationForbiddenForApp,
-    /// Invalid type tag for StructuredData
-    InvalidStructuredDataTypeTag,
     /// Invalid version number requested for a versioned StructuredData
     InvalidVersionNumber,
     /// Invalid offsets (from-position and lenght combination) provided for
@@ -126,10 +124,7 @@ impl From<IoError> for FfiError {
 
 impl From<CoreError> for FfiError {
     fn from(error: CoreError) -> FfiError {
-        match error {
-            CoreError::InvalidStructuredDataTypeTag => FfiError::InvalidStructuredDataTypeTag,
-            _ => FfiError::CoreError(Box::new(error)),
-        }
+        FfiError::CoreError(Box::new(error))
     }
 }
 
@@ -173,7 +168,6 @@ impl Into<i32> for FfiError {
             FfiError::InvalidEncryptKeyHandle => FFI_ERROR_START_RANGE - 17,
             FfiError::InvalidSignKeyHandle => FFI_ERROR_START_RANGE - 18,
             FfiError::OperationForbiddenForApp => FFI_ERROR_START_RANGE - 19,
-            FfiError::InvalidStructuredDataTypeTag => FFI_ERROR_START_RANGE - 20,
             FfiError::InvalidVersionNumber => FFI_ERROR_START_RANGE - 21,
             FfiError::InvalidSelfEncryptorReadOffsets => FFI_ERROR_START_RANGE - 22,
             FfiError::InvalidIndex => FFI_ERROR_START_RANGE - 23,
@@ -213,9 +207,6 @@ impl fmt::Debug for FfiError {
             FfiError::InvalidEncryptKeyHandle => write!(f, "FfiError::InvalidEncryptKeyHandle"),
             FfiError::InvalidSignKeyHandle => write!(f, "FfiError::InvalidSignKeyHandle"),
             FfiError::OperationForbiddenForApp => write!(f, "FfiError::OperationForbiddenForApp"),
-            FfiError::InvalidStructuredDataTypeTag => {
-                write!(f, "FfiError::InvalidStructuredDataTypeTag")
-            }
             FfiError::InvalidVersionNumber => write!(f, "FfiError::InvalidVersionNumber"),
             FfiError::InvalidSelfEncryptorReadOffsets => {
                 write!(f, "FfiError::InvalidSelfEncryptorReadOffsets")

--- a/src/ffi/launcher_config.rs
+++ b/src/ffi/launcher_config.rs
@@ -161,7 +161,8 @@ fn launcher_global_config_and_dir(client: &Client)
                                         LAUNCHER_GLOBAL_CONFIG_FILE_NAME.to_string(),
                                         Vec::new(),
                                         metadata.id(),
-                                        dir.clone())
+                                        dir.clone(),
+                                        false)
                         .and_then(move |writer| writer.close())
                         .map_err(FfiError::from)
                         .map(move |updated_dir| {

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -77,7 +77,6 @@ pub unsafe extern "C" fn output_log_path(c_output_file_name: *const u8,
 
 #[cfg(test)]
 mod tests {
-
     use std::env;
     use std::fs::File;
     use std::io::Read;

--- a/src/ffi/low_level_api/immut_data.rs
+++ b/src/ffi/low_level_api/immut_data.rs
@@ -462,11 +462,7 @@ mod tests {
             let read_tx: *mut _ = &mut read_tx;
             let read_tx = read_tx as *mut c_void;
 
-            assert_eq!(cipher_opt_new_asymmetric(&sess,
-                                                 app_1_encrypt_key_handle,
-                                                 handle_tx,
-                                                 handle_cb),
-                       0);
+            cipher_opt_new_asymmetric(&sess, app_1_encrypt_key_handle, handle_tx, handle_cb);
             let (err_code, cipher_opt_h) = unwrap!(handle_rx.recv());
             assert_eq!(err_code, 0);
 
@@ -554,11 +550,10 @@ mod tests {
             assert_eq!(unwrap!(err_code_rx.recv()),
                        FfiError::InvalidSelfEncryptorHandle.into());
 
-            assert_eq!(cipher_opt_free(&sess, cipher_opt_h, err_code_tx, err_code_cb),
-                       0);
+            cipher_opt_free(&sess, cipher_opt_h, err_code_tx, err_code_cb);
             assert_eq!(unwrap!(err_code_rx.recv()), 0);
 
-            assert_eq!(data_id_free(&sess, data_id_h, err_code_tx, err_code_cb), 0);
+            data_id_free(&sess, data_id_h, err_code_tx, err_code_cb);
             assert_eq!(unwrap!(err_code_rx.recv()), 0);
         }
     }

--- a/src/ffi/low_level_api/immut_data.rs
+++ b/src/ffi/low_level_api/immut_data.rs
@@ -182,8 +182,8 @@ pub unsafe extern "C" fn immut_data_close_self_encryptor(session: *const Session
                         .map_err(FfiError::from)
                         .map(move |_| {
                             let data_id = DataIdentifier::Immutable(raw_immut_data_name);
-                            let handle = unwrap!(obj_cache.lock()).insert_data_id(data_id);
-                            handle
+                            let mut obj_cache = unwrap!(obj_cache.lock());
+                            obj_cache.insert_data_id(data_id)
                         })
                         .into_box()
                 })

--- a/src/ffi/low_level_api/mod.rs
+++ b/src/ffi/low_level_api/mod.rs
@@ -31,5 +31,5 @@ pub mod data_id;
 pub mod immut_data;
 /// Miscellaneous routines
 pub mod misc;
-// /// Low level manipulation of StructuredData
-// pub mod struct_data;
+/// Low level manipulation of StructuredData
+pub mod struct_data;

--- a/src/ffi/low_level_api/struct_data/mod.rs
+++ b/src/ffi/low_level_api/struct_data/mod.rs
@@ -19,6 +19,9 @@
 // Please review the Licences for the specific language governing permissions
 // and limitations relating to use of the SAFE Network Software.
 
+#[cfg(test)]
+mod tests;
+
 use core::{CLIENT_STRUCTURED_DATA_TAG, CoreError};
 use core::futures::FutureExt;
 use core::structured_data::{self, unversioned, versioned};
@@ -29,15 +32,6 @@ use libc::{c_void, int32_t, uint64_t};
 use routing::{Data, StructuredData, XorName, XOR_NAME_LEN};
 use std::{ptr, slice};
 use super::cipher_opt::CipherOpt;
-
-
-// use core::immut_data_operations;
-// use core::client::Client;
-// use ffi::low_level_api::object_cache::object_cache;
-// use maidsafe_utilities::serialisation::{deserialise, serialise};
-// use routing::{DataIdentifier, ImmutableData, NO_OWNER_PUB_KEY};
-// use std::mem;
-// use std::sync::{Arc, Mutex};
 
 // TOOD: consider moving this macro to ffi::macros as it might be useful elsewhere.
 macro_rules! try_cb {
@@ -63,7 +57,7 @@ pub unsafe extern "C" fn struct_data_new(session: *const Session,
                                          data: *const u8,
                                          data_len: usize,
                                          user_data: *mut c_void,
-                                         o_cb: extern "C" fn(*mut c_void, int32_t, StructDataHandle)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t, StructDataHandle)) {
     helper::catch_unwind_cb(|| {
         let id = XorName(*id);
         let data = slice::from_raw_parts(data, data_len);
@@ -134,7 +128,7 @@ pub unsafe extern "C" fn struct_data_new(session: *const Session,
 pub unsafe extern "C" fn struct_data_fetch(session: *const Session,
                                            data_id_h: DataIdHandle,
                                            user_data: *mut c_void,
-                                           o_cb: extern "C" fn(*mut c_void, int32_t, StructDataHandle)) {
+                                           o_cb: unsafe extern "C" fn(*mut c_void, int32_t, StructDataHandle)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| {
             let data_id = {
@@ -168,7 +162,7 @@ pub unsafe extern "C" fn struct_data_fetch(session: *const Session,
 pub unsafe extern "C" fn struct_data_extract_data_id(session: *const Session,
                                                      sd_h: StructDataHandle,
                                                      user_data: *mut c_void,
-                                                     o_cb: extern "C" fn(*mut c_void, int32_t, DataIdHandle)) {
+                                                     o_cb: unsafe extern "C" fn(*mut c_void, int32_t, DataIdHandle)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |_, object_cache, user_data| -> Option<Result<_, _>> {
             let mut object_cache = unwrap!(object_cache.lock());
@@ -195,7 +189,7 @@ pub unsafe extern "C" fn struct_data_update(session: *const Session,
                                             data: *const u8,
                                             data_len: usize,
                                             user_data: *mut c_void,
-                                            o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                            o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     helper::catch_unwind_cb(|| {
         let data = slice::from_raw_parts(data, data_len);
 
@@ -275,7 +269,7 @@ pub unsafe extern "C" fn struct_data_extract_data(session: *const Session,
                                                   app_h: AppHandle,
                                                   sd_h: StructDataHandle,
                                                   user_data: *mut c_void,
-                                                  o_cb: extern "C" fn(*mut c_void, int32_t, *mut u8, usize, usize)) {
+                                                  o_cb: unsafe extern "C" fn(*mut c_void, int32_t, *mut u8, usize, usize)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| {
             let fut = {
@@ -321,7 +315,7 @@ pub unsafe extern "C" fn struct_data_extract_data(session: *const Session,
 pub unsafe extern "C" fn struct_data_num_of_versions(session: *const Session,
                                                      sd_h: StructDataHandle,
                                                      user_data: *mut c_void,
-                                                     o_cb: extern "C" fn(*mut c_void, int32_t, uint64_t)) {
+                                                     o_cb: unsafe extern "C" fn(*mut c_void, int32_t, uint64_t)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |_, object_cache, user_data| -> Option<Result<_, _>> {
             let mut object_cache = unwrap!(object_cache.lock());
@@ -345,7 +339,7 @@ pub unsafe extern "C" fn struct_data_nth_version(session: *const Session,
                                                  sd_h: StructDataHandle,
                                                  n: uint64_t,
                                                  user_data: *mut c_void,
-                                                 o_cb: extern "C" fn(*mut c_void, int32_t, *mut u8, usize, usize)) {
+                                                 o_cb: unsafe extern "C" fn(*mut c_void, int32_t, *mut u8, usize, usize)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| {
             let fut = {
@@ -385,7 +379,7 @@ pub unsafe extern "C" fn struct_data_nth_version(session: *const Session,
 pub unsafe extern "C" fn struct_data_version(session: *const Session,
                                              handle: StructDataHandle,
                                              user_data: *mut c_void,
-                                             o_cb: extern "C" fn(*mut c_void, int32_t, uint64_t)) {
+                                             o_cb: unsafe extern "C" fn(*mut c_void, int32_t, uint64_t)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |_, object_cache, user_data| -> Option<Result<_, _>> {
             let mut object_cache = unwrap!(object_cache.lock());
@@ -402,7 +396,7 @@ pub unsafe extern "C" fn struct_data_version(session: *const Session,
 pub unsafe extern "C" fn struct_data_put(session: *const Session,
                                          sd_h: StructDataHandle,
                                          user_data: *mut c_void,
-                                         o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| {
             let sd = {
@@ -411,8 +405,12 @@ pub unsafe extern "C" fn struct_data_put(session: *const Session,
                         |error| o_cb(user_data, error)).clone()
             };
 
+            // TODO: use put_recover
             client.put(Data::Structured(sd), None)
-                .map(move |_| o_cb(user_data, 0))
+                .map(move |_| {
+                    // TODO update the version of the data stored in the object cache
+                    o_cb(user_data, 0)
+                })
                 .map_err(move |err| {
                     let err = FfiError::from(err);
                     o_cb(user_data, ffi_error_code!(err));
@@ -427,7 +425,7 @@ pub unsafe extern "C" fn struct_data_put(session: *const Session,
 pub unsafe extern "C" fn struct_data_post(session: *const Session,
                                           sd_h: StructDataHandle,
                                           user_data: *mut c_void,
-                                          o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| {
             let sd = {
@@ -452,7 +450,7 @@ pub unsafe extern "C" fn struct_data_post(session: *const Session,
 pub unsafe extern "C" fn struct_data_delete(session: *const Session,
                                             sd_h: StructDataHandle,
                                             user_data: *mut c_void,
-                                            o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                            o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| {
             let sd = {
@@ -497,7 +495,7 @@ pub unsafe extern "C" fn struct_data_validate_size(session: *const Session,
 pub unsafe extern "C" fn struct_data_is_owned(session: *const Session,
                                               sd_h: StructDataHandle,
                                               user_data: *mut c_void,
-                                              o_cb: extern "C" fn(*mut c_void, int32_t, bool)) {
+                                              o_cb: unsafe extern "C" fn(*mut c_void, int32_t, bool)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |client, object_cache, user_data| -> Option<Result<_, _>> {
             let mut object_cache = unwrap!(object_cache.lock());
@@ -517,335 +515,14 @@ pub unsafe extern "C" fn struct_data_is_owned(session: *const Session,
 pub unsafe extern "C" fn struct_data_free(session: *const Session,
                                           handle: StructDataHandle,
                                           user_data: *mut c_void,
-                                          o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     helper::catch_unwind_cb(|| {
         (*session).send_cb(user_data, move |_, object_cache, user_data| -> Option<Result<_, _>> {
             let mut object_cache = unwrap!(object_cache.lock());
             let _ = try_cb!(object_cache.remove_sd(handle), |error| o_cb(user_data, error));
+
+            o_cb(user_data, 0);
             None
         })
     }, move |error| o_cb(user_data, error))
-}
-
-#[cfg(test)]
-mod tests {
-    /*
-    use core::{CLIENT_STRUCTURED_DATA_TAG, utility};
-    use ffi::app::App;
-    use ffi::errors::FfiError;
-    use ffi::low_level_api::{CipherOptHandle, DataIdHandle, StructDataHandle};
-    use ffi::low_level_api::cipher_opt::*;
-    use ffi::low_level_api::object_cache::object_cache;
-    use ffi::test_utils;
-    use rand;
-    use std::ptr;
-    use super::*;
-
-    #[test]
-    fn unversioned_struct_data_crud() {
-        let app = test_utils::create_app(false);
-
-        let mut cipher_opt_h: CipherOptHandle = 0;
-        let mut sd_h: StructDataHandle = 0;
-        let mut data_id_h: DataIdHandle = 0;
-        let id = rand::random();
-        let mut plain_text = unwrap!(utility::generate_random_vector::<u8>(10));
-        unsafe {
-            assert_eq!(cipher_opt_new_symmetric(&mut cipher_opt_h), 0);
-
-            // Create
-            assert_eq!(struct_data_new(&app,
-                                       ::UNVERSIONED_STRUCT_DATA_TYPE_TAG,
-                                       &id,
-                                       0,
-                                       cipher_opt_h,
-                                       plain_text.as_ptr(),
-                                       plain_text.len(),
-                                       &mut sd_h),
-                       0);
-            assert_eq!(struct_data_extract_data_id(sd_h, &mut data_id_h), 0);
-
-            // Put
-            assert_eq!(struct_data_put(&app, sd_h), 0);
-            let _ = unwrap!(object_cache()).get_sd(sd_h);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert!(unwrap!(object_cache()).get_sd(sd_h).is_err());
-
-            // Fetch
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-            let _ = unwrap!(object_cache()).get_sd(sd_h);
-
-            // Extract Data
-            let rx_plain_text_0 = extract_data(&app, sd_h);
-            assert_eq!(rx_plain_text_0, plain_text);
-
-            // New Data
-            plain_text = unwrap!(utility::generate_random_vector::<u8>(10));
-            assert_eq!(struct_data_new_data(&app,
-                                            sd_h,
-                                            cipher_opt_h,
-                                            plain_text.as_ptr(),
-                                            plain_text.len()),
-                       0);
-
-            // Post
-            assert_eq!(struct_data_post(&app, sd_h), 0);
-            let _ = unwrap!(object_cache()).get_sd(sd_h);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert!(unwrap!(object_cache()).get_sd(sd_h).is_err());
-
-            // Fetch
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-            let _ = unwrap!(object_cache()).get_sd(sd_h);
-
-            // Extract Data
-            let rx_plain_text_1 = extract_data(&app, sd_h);
-            assert_eq!(rx_plain_text_1, plain_text);
-            assert!(rx_plain_text_1 != rx_plain_text_0);
-
-
-            // Perform Invalid Operations - should error out
-            let mut versions = 0;
-            assert_eq!(struct_data_num_of_versions(sd_h, &mut versions),
-                       FfiError::InvalidStructuredDataTypeTag.into());
-            {
-                let mut data_ptr: *mut u8 = ptr::null_mut();
-                let mut data_size = 0;
-                let mut capacity = 0;
-                assert_eq!(struct_data_nth_version(&app,
-                                                   sd_h,
-                                                   0,
-                                                   &mut data_ptr,
-                                                   &mut data_size,
-                                                   &mut capacity),
-                           FfiError::InvalidStructuredDataTypeTag.into());
-            }
-
-            // Check StructData owners
-            let mut is_owned = false;
-            assert_eq!(struct_data_is_owned(&app, sd_h, &mut is_owned), 0);
-            assert_eq!(is_owned, true);
-
-            let app_fake = test_utils::create_app(false);
-            assert_eq!(struct_data_is_owned(&app_fake, sd_h, &mut is_owned), 0);
-            assert_eq!(is_owned, false);
-
-            // Delete
-            assert_eq!(struct_data_delete(&app, sd_h), 0);
-            let _ = unwrap!(object_cache()).get_sd(sd_h);
-
-            // Re-delete shold fail - MutationError::NoSuchData; Fetch should be successful
-            assert_eq!(struct_data_delete(&app, sd_h), -22);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert_eq!(struct_data_free(sd_h),
-                       FfiError::InvalidStructDataHandle.into());
-            assert!(unwrap!(object_cache()).get_sd(sd_h).is_err());
-
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert_eq!(struct_data_free(sd_h),
-                       FfiError::InvalidStructDataHandle.into());
-
-            // Re-claim via PUT
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-            let mut version = 0;
-            assert_eq!(struct_data_version(sd_h, &mut version), 0);
-            assert_eq!(struct_data_free(sd_h), 0);
-            // Create
-            assert_eq!(struct_data_new(&app,
-                                       ::UNVERSIONED_STRUCT_DATA_TYPE_TAG,
-                                       &id,
-                                       version + 1,
-                                       cipher_opt_h,
-                                       plain_text.as_ptr(),
-                                       plain_text.len(),
-                                       &mut sd_h),
-                       0);
-            // Put - Reclaim
-            assert_eq!(struct_data_put(&app, sd_h), 0);
-        }
-    }
-
-    #[test]
-    fn versioned_struct_data_crud() {
-        let app = test_utils::create_app(false);
-
-        let mut cipher_opt_h: CipherOptHandle = 0;
-        let mut sd_h: StructDataHandle = 0;
-        let mut data_id_h: DataIdHandle = 0;
-
-        let name = rand::random();
-        let data0 = unwrap!(utility::generate_random_vector(10));
-        let data1 = unwrap!(utility::generate_random_vector(10));
-
-        unsafe {
-            assert_eq!(cipher_opt_new_symmetric(&mut cipher_opt_h), 0);
-
-            // Create
-            assert_eq!(struct_data_new(&app,
-                                       ::VERSIONED_STRUCT_DATA_TYPE_TAG,
-                                       &name,
-                                       0,
-                                       cipher_opt_h,
-                                       data0.as_ptr(),
-                                       data0.len(),
-                                       &mut sd_h),
-                       0);
-            assert_eq!(struct_data_extract_data_id(sd_h, &mut data_id_h), 0);
-
-            // Put and re-fetch
-            assert_eq!(struct_data_put(&app, sd_h), 0);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-
-            // Check content
-            let mut num_versions = 0usize;
-            assert_eq!(struct_data_num_of_versions(sd_h, &mut num_versions), 0);
-            assert_eq!(num_versions, 1);
-            assert_eq!(nth_version(&app, sd_h, 0), data0);
-
-            let mut version = 0;
-            assert_eq!(struct_data_version(sd_h, &mut version), 0);
-            assert_eq!(version, 0);
-
-            assert_eq!(extract_data(&app, sd_h), data0);
-
-            // Update the content
-            assert_eq!(struct_data_new_data(&app, sd_h, cipher_opt_h, data1.as_ptr(), data1.len()),
-                       0);
-
-            // Post and re-fetch
-            assert_eq!(struct_data_post(&app, sd_h), 0);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-
-            // Check content
-            assert_eq!(struct_data_num_of_versions(sd_h, &mut num_versions), 0);
-            assert_eq!(num_versions, 2);
-            assert_eq!(nth_version(&app, sd_h, 0), data0);
-            assert_eq!(nth_version(&app, sd_h, 1), data1);
-
-            assert_eq!(extract_data(&app, sd_h), data1);
-
-            let mut version = 0;
-            assert_eq!(struct_data_version(sd_h, &mut version), 0);
-            assert_eq!(version, 1);
-
-            // Delete
-            assert_eq!(struct_data_delete(&app, sd_h), 0);
-            // -26 is CoreError::MutationFailure { reason: MutationError::InvalidOperation }
-            assert_eq!(struct_data_delete(&app, sd_h), -26);
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-        }
-    }
-
-    #[test]
-    fn client_struct_data_crud() {
-        let app = test_utils::create_app(false);
-
-        let mut cipher_opt_h: CipherOptHandle = 0;
-        let mut sd_h: StructDataHandle = 0;
-        let mut data_id_h: DataIdHandle = 0;
-
-        let name = rand::random();
-        let data0 = unwrap!(utility::generate_random_vector(10));
-        let data1 = unwrap!(utility::generate_random_vector(10));
-
-        unsafe {
-            assert_eq!(cipher_opt_new_symmetric(&mut cipher_opt_h), 0);
-
-            // Invalid client tag
-            assert_eq!(struct_data_new(&app,
-                                       CLIENT_STRUCTURED_DATA_TAG - 1,
-                                       &name,
-                                       0,
-                                       cipher_opt_h,
-                                       data0.as_ptr(),
-                                       data0.len(),
-                                       &mut sd_h),
-                       FfiError::InvalidStructuredDataTypeTag.into());
-
-            // Create
-            assert_eq!(struct_data_new(&app,
-                                       CLIENT_STRUCTURED_DATA_TAG + 1,
-                                       &name,
-                                       0,
-                                       cipher_opt_h,
-                                       data0.as_ptr(),
-                                       data0.len(),
-                                       &mut sd_h),
-                       0);
-            assert_eq!(struct_data_extract_data_id(sd_h, &mut data_id_h), 0);
-
-            // Put and re-fetch
-            assert_eq!(struct_data_put(&app, sd_h), 0);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-
-            // Check content
-            assert_eq!(extract_data(&app, sd_h), data0);
-
-            // Update the content
-            assert_eq!(struct_data_new_data(&app, sd_h, cipher_opt_h, data1.as_ptr(), data1.len()),
-                       0);
-
-            // Post and re-fetch
-            assert_eq!(struct_data_post(&app, sd_h), 0);
-            assert_eq!(struct_data_free(sd_h), 0);
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-
-            // Check content
-            assert_eq!(extract_data(&app, sd_h), data1);
-
-            // Invalid operations
-            let mut num_versions = 0;
-            assert_eq!(struct_data_num_of_versions(sd_h, &mut num_versions),
-                       FfiError::InvalidStructuredDataTypeTag.into());
-
-            // Delete
-            assert_eq!(struct_data_delete(&app, sd_h), 0);
-            // -26 is CoreError::MutationFailure { reason: MutationError::InvalidOperation }
-            assert_eq!(struct_data_delete(&app, sd_h), -26);
-            assert_eq!(struct_data_fetch(&app, data_id_h, &mut sd_h), 0);
-        }
-    }
-
-    // Helper function to fetch the current data from the structured data using FFI.
-    fn extract_data(app: &App, sd_h: StructDataHandle) -> Vec<u8> {
-        let mut data_ptr = ptr::null_mut();
-        let mut data_size = 0usize;
-        let mut data_cap = 0usize;
-
-        unsafe {
-            assert_eq!(struct_data_extract_data(app,
-                                                sd_h,
-                                                &mut data_ptr,
-                                                &mut data_size,
-                                                &mut data_cap),
-                       0);
-
-            Vec::from_raw_parts(data_ptr, data_size, data_cap)
-        }
-    }
-
-    // Helper function to fetch the nth version from the structured data using FFI.
-    fn nth_version(app: &App, sd_h: StructDataHandle, n: usize) -> Vec<u8> {
-        let mut data_ptr = ptr::null_mut();
-        let mut data_size = 0usize;
-        let mut data_cap = 0usize;
-
-        unsafe {
-            assert_eq!(struct_data_nth_version(app,
-                                               sd_h,
-                                               n,
-                                               &mut data_ptr,
-                                               &mut data_size,
-                                               &mut data_cap),
-                       0);
-
-            Vec::from_raw_parts(data_ptr, data_size, data_cap)
-        }
-    }
-
-    */
 }

--- a/src/ffi/low_level_api/struct_data/tests.rs
+++ b/src/ffi/low_level_api/struct_data/tests.rs
@@ -1,0 +1,582 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+use core::{CoreError, utility};
+use core::CLIENT_STRUCTURED_DATA_TAG;
+use ffi::{FfiError, Session, test_utils};
+use ffi::low_level_api::cipher_opt::*;
+use ffi::object_cache::{AppHandle, CipherOptHandle, ObjectCache};
+use rand;
+use routing::XOR_NAME_LEN;
+use std::sync::{Arc, Mutex};
+use super::*;
+
+#[test]
+fn unversioned_struct_data_crud() {
+    let (session, object_cache, app_h, cipher_opt_h) = setup_session();
+
+    // Create SD
+    let id: [u8; XOR_NAME_LEN] = rand::random();
+    let content_0 = unwrap!(utility::generate_random_vector::<u8>(10));
+
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_new(&session,
+                            app_h,
+                            ::UNVERSIONED_STRUCT_DATA_TYPE_TAG,
+                            &id,
+                            0,
+                            cipher_opt_h,
+                            content_0.as_ptr(),
+                            content_0.len(),
+                            user_data,
+                            cb)
+        }))
+    };
+
+    let sd_data_id_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_extract_data_id(&session, sd_h, user_data, cb)
+        }))
+    };
+
+    // PUT
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_put(&session, sd_h, user_data, cb)
+        }))
+    }
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let sd = unwrap!(object_cache.get_sd(sd_h));
+        assert_eq!(sd.get_version(), 0);
+    }
+
+    // Remove SD from the object cache.
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_free(&session, sd_h, user_data, cb)
+        }))
+    }
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        assert!(object_cache.get_sd(sd_h).is_err());
+    }
+
+    // GET
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let _ = unwrap!(object_cache.get_sd(sd_h));
+    }
+
+    // Extract Data
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_extract_data(&session, app_h, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_0);
+
+    // Update data
+    let content_1 = unwrap!(utility::generate_random_vector::<u8>(10));
+
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_update(&session,
+                               app_h,
+                               sd_h,
+                               cipher_opt_h,
+                               content_1.as_ptr(),
+                               content_1.len(),
+                               user_data,
+                               cb)
+        }))
+    }
+
+    // POST
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_post(&session, sd_h, user_data, cb)
+        }))
+    }
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let sd = unwrap!(object_cache.get_sd(sd_h));
+        assert_eq!(sd.get_version(), 1);
+    }
+
+    // Remove SD from the object cache.
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_free(&session, sd_h, user_data, cb)
+        }))
+    }
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        assert!(object_cache.get_sd(sd_h).is_err());
+    }
+
+    // Fetch
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let _ = unwrap!(object_cache.get_sd(sd_h));
+    }
+
+    // Extract Data
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_extract_data(&session, app_h, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_1);
+
+    // Perform Invalid Operations - should error out
+    let result = unsafe {
+        test_utils::call_1(|user_data, cb| {
+            struct_data_num_of_versions(&session, sd_h, user_data, cb)
+        })
+    };
+    match result {
+        Ok(_) => panic!("Unexpected success"),
+        Err(error_code) => assert_eq!(error_code, FfiError::from(CoreError::InvalidStructuredDataTypeTag).into()),
+    }
+
+    let result = unsafe {
+        test_utils::call_3(|user_data, cb| {
+            struct_data_nth_version(&session, app_h, sd_h, 0, user_data, cb)
+        })
+    };
+    match result {
+        Ok(_) => panic!("Unexpected success"),
+        Err(error_code) => assert_eq!(error_code, FfiError::from(CoreError::InvalidStructuredDataTypeTag).into()),
+    }
+
+    // Check SD owners
+    let is_owned = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_is_owned(&session, sd_h, user_data, cb)
+        }))
+    };
+    assert!(is_owned);
+
+    let other_session = test_utils::create_session();
+    let other_sd_data_id_h = {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let data_id = *unwrap!(object_cache.get_data_id(sd_data_id_h));
+
+        let object_cache = other_session.object_cache();
+        let mut object_cache = unwrap!(object_cache.lock());
+        object_cache.insert_data_id(data_id)
+    };
+
+    let other_sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&other_session, other_sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    let is_owned = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_is_owned(&other_session, other_sd_h, user_data, cb)
+        }))
+    };
+    assert!(!is_owned);
+
+    // Clone the SD to simulate Re-deletion later
+    let sd_clone_h = {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let sd_clone = unwrap!(object_cache.get_sd(sd_h)).clone();
+        object_cache.insert_sd(sd_clone)
+    };
+
+    // DELETE
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_delete(&session, sd_h, user_data, cb)
+        }))
+    }
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        assert!(object_cache.get_sd(sd_h).is_err());
+    }
+
+    // Re-DELETE should fail
+    let result = unsafe {
+        test_utils::call_0(|user_data, cb| {
+            struct_data_delete(&session, sd_clone_h, user_data, cb)
+        })
+    };
+    match result {
+        Ok(_) => panic!("Unexpected success"),
+        Err(error_code) => {
+            // -26 is InvalidOperation
+            assert_eq!(error_code, -26);
+        }
+    }
+
+    // Fetch deleted data is OK
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    {
+        let mut object_cache = unwrap!(object_cache.lock());
+        let sd = unwrap!(object_cache.get_sd(sd_h));
+        assert!(sd.is_deleted());
+        assert_eq!(sd.get_version(), 2);
+    }
+
+    // Re-claim via PUT
+    let content_2 = unwrap!(utility::generate_random_vector(10));
+    unsafe {
+        let sd_h = unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_new(&session,
+                            app_h,
+                            ::UNVERSIONED_STRUCT_DATA_TYPE_TAG,
+                            &id,
+                            3,
+                            cipher_opt_h,
+                            content_2.as_ptr(),
+                            content_2.len(),
+                            user_data,
+                            cb)
+        }));
+
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_put(&session, sd_h, user_data, cb)
+        }));
+    };
+}
+
+#[test]
+fn versioned_struct_data_crud() {
+    let (session, _, app_h, cipher_opt_h) = setup_session();
+
+    // Create SD
+    let id = rand::random();
+    let content_0 = unwrap!(utility::generate_random_vector(10));
+
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_new(&session,
+                            app_h,
+                            ::VERSIONED_STRUCT_DATA_TYPE_TAG,
+                            &id,
+                            0,
+                            cipher_opt_h,
+                            content_0.as_ptr(),
+                            content_0.len(),
+                            user_data,
+                            cb)
+        }))
+    };
+
+    let sd_data_id_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_extract_data_id(&session, sd_h, user_data, cb)
+        }))
+    };
+
+    // PUT and Fetch
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_put(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_free(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    // Check content
+    let num_versions = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_num_of_versions(&session, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(num_versions, 1);
+
+    let version = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_version(&session, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(version, 0);
+
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_nth_version(&session, app_h, sd_h, 0, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_0);
+
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_extract_data(&session, app_h, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_0);
+
+    // Update the content
+    let content_1 = unwrap!(utility::generate_random_vector(10));
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_update(&session,
+                               app_h,
+                               sd_h,
+                               cipher_opt_h,
+                               content_1.as_ptr(),
+                               content_1.len(),
+                               user_data,
+                               cb)
+        }))
+    }
+
+    // POST and Fetch
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_post(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_free(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    // Check content
+    let num_versions = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_num_of_versions(&session, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(num_versions, 2);
+
+    let version = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_version(&session, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(version, 1);
+
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_nth_version(&session, app_h, sd_h, 0, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_0);
+
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_nth_version(&session, app_h, sd_h, 1, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_1);
+
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_extract_data(&session, app_h, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_1);
+
+    // DELETE
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_delete(&session, sd_h, user_data, cb)
+        }))
+    }
+}
+
+#[test]
+fn client_struct_data_crud() {
+    let (session, _, app_h, cipher_opt_h) = setup_session();
+
+    let id = rand::random();
+    let content_0 = unwrap!(utility::generate_random_vector(10));
+
+    // Create with invalid client tag
+    let result = unsafe {
+        test_utils::call_1(|user_data, cb| {
+            struct_data_new(&session,
+                            app_h,
+                            CLIENT_STRUCTURED_DATA_TAG - 1,
+                            &id,
+                            0,
+                            cipher_opt_h,
+                            content_0.as_ptr(),
+                            content_0.len(),
+                            user_data,
+                            cb)
+        })
+    };
+    match result {
+        Ok(_) => panic!("Unexpected success"),
+        Err(error_code) => assert_eq!(error_code, FfiError::from(CoreError::InvalidStructuredDataTypeTag).into()),
+    }
+
+    // Create
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_new(&session,
+                            app_h,
+                            CLIENT_STRUCTURED_DATA_TAG + 1,
+                            &id,
+                            0,
+                            cipher_opt_h,
+                            content_0.as_ptr(),
+                            content_0.len(),
+                            user_data,
+                            cb)
+        }))
+    };
+
+    let sd_data_id_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_extract_data_id(&session, sd_h, user_data, cb)
+        }))
+    };
+
+    // PUT and Fetch
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_put(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_free(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    // Check content
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_extract_data(&session, app_h, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_0);
+
+    // Update the content
+    let content_1 = unwrap!(utility::generate_random_vector(10));
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_update(&session,
+                               app_h,
+                               sd_h,
+                               cipher_opt_h,
+                               content_1.as_ptr(),
+                               content_1.len(),
+                               user_data,
+                               cb)
+        }))
+    }
+
+    // POST and Fetch
+    let sd_h = unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_post(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_free(&session, sd_h, user_data, cb)
+        }));
+
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            struct_data_fetch(&session, sd_data_id_h, user_data, cb)
+        }))
+    };
+
+    // Check content
+    let retrieved_content = unsafe {
+        unwrap!(test_utils::call_vec_u8(|user_data, cb| {
+            struct_data_extract_data(&session, app_h, sd_h, user_data, cb)
+        }))
+    };
+    assert_eq!(retrieved_content, content_1);
+
+    // Invalid operations
+    let result = unsafe {
+        test_utils::call_1(|user_data, cb| {
+            struct_data_num_of_versions(&session, sd_h, user_data, cb)
+        })
+    };
+    match result {
+        Ok(_) => panic!("Unexpected success"),
+        Err(error_code) => assert_eq!(error_code, FfiError::from(CoreError::InvalidStructuredDataTypeTag).into()),
+    }
+
+    // DELETE
+    unsafe {
+        unwrap!(test_utils::call_0(|user_data, cb| {
+            struct_data_delete(&session, sd_h, user_data, cb)
+        }))
+    }
+}
+
+fn setup_session() -> (Session, Arc<Mutex<ObjectCache>>, AppHandle, CipherOptHandle) {
+    let session = test_utils::create_session();
+    let object_cache = session.object_cache();
+
+    let app = test_utils::create_app(&session, false);
+    let app_h = {
+        let mut object_cache = unwrap!(object_cache.lock());
+        object_cache.insert_app(app)
+    };
+
+    // Create cipher opt.
+    let cipher_opt_h = unsafe {
+        unwrap!(test_utils::call_1(|user_data, cb| {
+            cipher_opt_new_symmetric(&session, user_data, cb)
+        }))
+    };
+
+    (session, object_cache, app_h, cipher_opt_h)
+}

--- a/src/nfs/dir.rs
+++ b/src/nfs/dir.rs
@@ -194,16 +194,18 @@ mod tests {
     #[test]
     fn find_add_update_remove_file() {
         let mut dir = Dir::new();
-        let mut file = File::Unversioned(FileMetadata::new("index.html".to_string(),
-                                                           Vec::new(),
-                                                           DataMap::None));
+        let file = File::Unversioned(FileMetadata::new("index.html".to_string(),
+                                                       Vec::new(),
+                                                       DataMap::None));
         assert!(dir.find_file(file.name()).is_none());
 
         unwrap!(dir.add_file(file.clone()));
         assert!(dir.find_file(file.name()).is_some());
 
-        file.metadata_mut().set_name("home.html".to_string());
-        dir.update_file("index.html", file.clone());
+        let mut metadata = file.metadata().clone();
+        metadata.set_name("home.html".to_string());
+
+        dir.update_file("index.html", File::Unversioned(metadata));
         assert_eq!(dir.files().len(), 1);
         let file2 = File::Unversioned(FileMetadata::new("demo.html".to_string(),
                                                         Vec::new(),
@@ -211,11 +213,11 @@ mod tests {
         unwrap!(dir.add_file(file2.clone()));
         assert_eq!(dir.files().len(), 2);
 
-        let _ = unwrap!(dir.find_file(file.name()), "File not found");
+        let _ = unwrap!(dir.find_file("home.html"), "File not found");
         let _ = unwrap!(dir.find_file(file2.name()), "File not found");
 
-        let _ = unwrap!(dir.remove_file(file.metadata().name()));
-        assert!(dir.find_file(file.name()).is_none());
+        let _ = unwrap!(dir.remove_file("home.html"));
+        assert!(dir.find_file("home.html").is_none());
         assert!(dir.find_file(file2.name()).is_some());
         assert_eq!(dir.files().len(), 1);
 

--- a/src/nfs/file.rs
+++ b/src/nfs/file.rs
@@ -49,18 +49,11 @@ pub enum File {
 
 impl File {
     /// Get metadata associated with the file
+    /// For a versioned file the latest version is returned
     pub fn metadata(&self) -> &FileMetadata {
         match *self {
             File::Unversioned(ref metadata) => metadata,
             File::Versioned { ref latest_version, .. } => latest_version,
-        }
-    }
-
-    /// Get metadata associated with the file, with mutability to allow updation
-    pub fn metadata_mut(&mut self) -> &mut FileMetadata {
-        match *self {
-            File::Unversioned(ref mut id) => id,
-            File::Versioned { ref mut latest_version, .. } => latest_version,
         }
     }
 


### PR DESCRIPTION
* Implements StructData in low level API (from PR #372)
* Integrates latest changes in `low_level_api::misc` from the master branch (MAID-1666).
* Implements versioned files API in FFI (MAID-1626).