### PR TITLE
Ffi refactor

### DIFF
--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -53,11 +53,6 @@ const CONNECTION_TIMEOUT_SECS: u64 = 10;
 const IMMUT_DATA_CACHE_SIZE: usize = 300;
 const REQUEST_TIMEOUT_SECS: u64 = 120;
 
-#[cfg(test)]
-const REQUEST_TIMEOUT_SECS: u64 = 5;
-#[cfg(not(test))]
-const REQUEST_TIMEOUT_SECS: u64 = 120;
-
 /// The main self-authentication client instance that will interface all the
 /// request from high level API's to the actual routing layer and manage all
 /// interactions with it. This is essentially a non-blocking Client with upper

--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -53,6 +53,11 @@ const CONNECTION_TIMEOUT_SECS: u64 = 10;
 const IMMUT_DATA_CACHE_SIZE: usize = 300;
 const REQUEST_TIMEOUT_SECS: u64 = 120;
 
+#[cfg(test)]
+const REQUEST_TIMEOUT_SECS: u64 = 5;
+#[cfg(not(test))]
+const REQUEST_TIMEOUT_SECS: u64 = 120;
+
 /// The main self-authentication client instance that will interface all the
 /// request from high level API's to the actual routing layer and manage all
 /// interactions with it. This is essentially a non-blocking Client with upper

--- a/src/ffi/callback.rs
+++ b/src/ffi/callback.rs
@@ -1,0 +1,146 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+//! Helpers to work with extern "C" callbacks.
+
+use libc::{c_void, int32_t};
+use std::ptr;
+
+// This trait allows us to treat callbacks with different number and type of
+// arguments uniformly.
+pub trait Callback {
+    type Args: CallbackArgs;
+    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args);
+}
+
+// TODO: remove the impls for unsafe fn's (after we decide all callbacks should be safe).
+
+impl Callback for extern "C" fn(*mut c_void, int32_t) {
+    type Args = ();
+    fn call(&self, user_data: *mut c_void, error: int32_t, _args: Self::Args) {
+        self(user_data, error)
+    }
+}
+
+impl Callback for unsafe extern "C" fn(*mut c_void, int32_t) {
+    type Args = ();
+    fn call(&self, user_data: *mut c_void, error: int32_t, _args: Self::Args) {
+        unsafe { self(user_data, error) }
+    }
+}
+
+impl<T: CallbackArgs> Callback for extern "C" fn(*mut c_void, int32_t, a: T) {
+    type Args = T;
+    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+        self(user_data, error, args)
+    }
+}
+
+impl<T: CallbackArgs> Callback for unsafe extern "C" fn(*mut c_void, int32_t, a: T) {
+    type Args = T;
+    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+        unsafe { self(user_data, error, args) }
+    }
+}
+
+impl<T0: CallbackArgs, T1: CallbackArgs> Callback
+    for unsafe extern "C" fn(*mut c_void, int32_t, a0: T0, a1: T1) {
+    type Args = (T0, T1);
+    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+        unsafe { self(user_data, error, args.0, args.1) }
+    }
+}
+
+impl<T0: CallbackArgs, T1: CallbackArgs, T2: CallbackArgs> Callback
+    for extern "C" fn(*mut c_void, int32_t, a0: T0, a1: T1, a2: T2) {
+    type Args = (T0, T1, T2);
+    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+        self(user_data, error, args.0, args.1, args.2)
+    }
+}
+
+impl<T0: CallbackArgs, T1: CallbackArgs, T2: CallbackArgs> Callback
+    for unsafe extern "C" fn(*mut c_void, int32_t, a0: T0, a1: T1, a2: T2) {
+    type Args = (T0, T1, T2);
+    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+        unsafe { self(user_data, error, args.0, args.1, args.2) }
+    }
+}
+
+// This is similar to `Default`, but allows us to implement it for foreign types that
+// don't already implement `Default`.
+pub trait CallbackArgs {
+    fn default() -> Self;
+}
+
+impl CallbackArgs for () {
+    fn default() -> Self {
+        ()
+    }
+}
+
+impl CallbackArgs for bool {
+    fn default() -> Self {
+        false
+    }
+}
+
+impl CallbackArgs for i64 {
+    fn default() -> Self {
+        0
+    }
+}
+
+impl CallbackArgs for u64 {
+    fn default() -> Self {
+        0
+    }
+}
+
+impl CallbackArgs for usize {
+    fn default() -> Self {
+        0
+    }
+}
+
+impl<T> CallbackArgs for *const T {
+    fn default() -> Self {
+        ptr::null()
+    }
+}
+
+impl<T> CallbackArgs for *mut T {
+    fn default() -> Self {
+        ptr::null_mut()
+    }
+}
+
+impl<T0: CallbackArgs, T1: CallbackArgs> CallbackArgs for (T0, T1) {
+    fn default() -> Self {
+        (CallbackArgs::default(), CallbackArgs::default())
+    }
+}
+
+impl<T0: CallbackArgs, T1: CallbackArgs, T2: CallbackArgs> CallbackArgs for (T0, T1, T2) {
+    fn default() -> Self {
+        (CallbackArgs::default(), CallbackArgs::default(), CallbackArgs::default())
+    }
+}

--- a/src/ffi/dir_details.rs
+++ b/src/ffi/dir_details.rs
@@ -144,16 +144,18 @@ impl DirMetadata {
 #[no_mangle]
 pub unsafe extern "C" fn directory_details_get_metadata(details: *const DirDetails)
                                                         -> *const DirMetadata {
-    match (*details).metadata {
-        Some(ref metadata) => metadata,
-        None => ptr::null(),
-    }
+    helper::catch_unwind_ok(|| {
+        match (*details).metadata {
+            Some(ref metadata) => metadata,
+            None => ptr::null(),
+        }
+    })
 }
 
 /// Get the number of files in the directory.
 #[no_mangle]
 pub unsafe extern "C" fn directory_details_get_files_len(details: *const DirDetails) -> usize {
-    (*details).files.len()
+    helper::catch_unwind_ok(|| (*details).files.len())
 }
 
 /// Get a non-owning pointer to the metadata of the i-th file in the directory.
@@ -161,20 +163,22 @@ pub unsafe extern "C" fn directory_details_get_files_len(details: *const DirDeta
 pub unsafe extern "C" fn directory_details_get_file_at(details: *const DirDetails,
                                                        index: usize)
                                                        -> *const FileMetadata {
-    let details = &*details;
+    helper::catch_unwind_ok(|| {
+        let details = &*details;
 
-    if index < details.files.len() {
-        &details.files[index]
-    } else {
-        ptr::null()
-    }
+        if index < details.files.len() {
+            &details.files[index]
+        } else {
+            ptr::null()
+        }
+    })
 }
 
 /// Get the number of sub-directories in the directory.
 #[no_mangle]
 pub unsafe extern "C" fn directory_details_get_sub_directories_len(details: *const DirDetails)
                                                                    -> usize {
-    (*details).sub_dirs.len()
+    helper::catch_unwind_ok(|| (*details).sub_dirs.len())
 }
 
 /// Get a non-owning pointer to the metadata of the i-th sub-directory of the
@@ -183,17 +187,21 @@ pub unsafe extern "C" fn directory_details_get_sub_directories_len(details: *con
 pub unsafe extern "C" fn directory_details_get_sub_directory_at(details: *const DirDetails,
                                                                 index: usize)
                                                                 -> *const DirMetadata {
-    let details = &*details;
+    helper::catch_unwind_ok(|| {
+        let details = &*details;
 
-    if index < details.sub_dirs.len() {
-        &details.sub_dirs[index]
-    } else {
-        ptr::null()
-    }
+        if index < details.sub_dirs.len() {
+            &details.sub_dirs[index]
+        } else {
+            ptr::null()
+        }
+    })
 }
 
 /// Dispose of the DirDetails instance.
 #[no_mangle]
 pub unsafe extern "C" fn directory_details_free(details: *mut DirDetails) {
-    let _ = Box::from_raw(details);
+    helper::catch_unwind_ok(|| {
+        let _ = Box::from_raw(details);
+    })
 }

--- a/src/ffi/dns/file.rs
+++ b/src/ffi/dns/file.rs
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn dns_get_file(session: *const Session,
                                       include_metadata: bool,
                                       user_data: *mut c_void,
                                       o_cb: extern "C" fn(*mut c_void, int32_t, *mut FileDetails)) {
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let long_name = try!(helper::c_utf8_to_string(long_name, long_name_len));
         let service_name = try!(helper::c_utf8_to_string(service_name, service_name_len));
         let file_path = try!(helper::c_utf8_to_string(file_path, file_path_len));
@@ -80,8 +80,7 @@ pub unsafe extern "C" fn dns_get_file(session: *const Session,
 
             Some(fut)
         })
-    },
-                            move |error| o_cb(user_data, error, ptr::null_mut()))
+    })
 }
 
 /// Get file metadata.
@@ -97,7 +96,7 @@ pub unsafe extern "C" fn dns_get_file_metadata(session: *const Session,
                                                o_cb: extern "C" fn(*mut c_void,
                                                                    int32_t,
                                                                    *mut FileMetadata)) {
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let long_name = try!(helper::c_utf8_to_string(long_name, long_name_len));
         let service_name = try!(helper::c_utf8_to_string(service_name, service_name_len));
         let file_path = try!(helper::c_utf8_to_string(file_path, file_path_len));
@@ -131,8 +130,7 @@ pub unsafe extern "C" fn dns_get_file_metadata(session: *const Session,
 
             Some(fut)
         })
-    },
-                            move |error| o_cb(user_data, error, ptr::null_mut()))
+    })
 }
 
 #[cfg(test)]

--- a/src/ffi/low_level_api/cipher_opt.rs
+++ b/src/ffi/low_level_api/cipher_opt.rs
@@ -104,14 +104,13 @@ pub unsafe extern "C" fn cipher_opt_new_plaintext(session: *const Session,
                                                                              CipherOptHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let handle = obj_cache.insert_cipher_opt(CipherOpt::PlainText);
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 /// Construct CipherOpt::Symmetric handle
@@ -121,15 +120,14 @@ pub unsafe extern "C" fn cipher_opt_new_symmetric(session: *const Session,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
                                                                              int32_t,
                                                                              CipherOptHandle)) {
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
         (*session).send(move |_, obj_cache| {
             let handle = obj_cache.insert_cipher_opt(CipherOpt::Symmetric);
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            |error| o_cb(user_data, ffi_error_code!(error), 0))
+    })
 }
 
 /// Construct CipherOpt::Asymmetric handle
@@ -142,7 +140,7 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(session: *const Session,
                                                                               CipherOptHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let pk = match obj_cache.get_encrypt_key(peer_encrypt_key_h) {
                 Ok(pk) => *pk,
@@ -156,8 +154,7 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(session: *const Session,
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 /// Free CipherOpt handle
@@ -168,14 +165,13 @@ pub unsafe extern "C" fn cipher_opt_free(session: *const Session,
                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let res = obj_cache.remove_cipher_opt(handle);
             o_cb(user_data.0, ffi_result_code!(res));
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err)));
+    });
 }
 
 #[cfg(test)]

--- a/src/ffi/low_level_api/data_id.rs
+++ b/src/ffi/low_level_api/data_id.rs
@@ -32,19 +32,17 @@ pub unsafe extern "C" fn data_id_new_struct_data(session: *const Session,
                                                  user_data: *mut c_void,
                                                  o_cb: unsafe extern "C" fn(*mut c_void,
                                                                             int32_t,
-                                                                            DataIdHandle))
-                                                 -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                            DataIdHandle)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let xor_id = XorName(*id);
         let data_id = DataIdentifier::Structured(xor_id, type_tag);
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |_, obj_cache| {
+        (*session).send(move |_, obj_cache| {
             let handle = obj_cache.insert_data_id(data_id);
             o_cb(user_data.0, 0, handle);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -108,14 +106,13 @@ pub unsafe extern "C" fn data_id_free(session: *const Session,
                                       o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let res = obj_cache.remove_data_id(handle);
             o_cb(user_data.0, ffi_result_code!(res));
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err)));
+    });
 }
 
 #[cfg(test)]
@@ -151,8 +148,7 @@ mod tests {
             let tx: *mut _ = &mut tx;
             let tx = tx as *mut c_void;
 
-            assert_eq!(data_id_new_struct_data(sess_ptr, type_tag, &struct_id_arr, tx, data_id_cb),
-                       0);
+            data_id_new_struct_data(sess_ptr, type_tag, &struct_id_arr, tx, data_id_cb);
             data_id_handle_struct = unwrap!(rx.recv());
 
             assert_eq!(data_id_new_immut_data(sess_ptr, &immut_id_arr, tx, data_id_cb),

--- a/src/ffi/low_level_api/data_id.rs
+++ b/src/ffi/low_level_api/data_id.rs
@@ -53,19 +53,17 @@ pub unsafe extern "C" fn data_id_new_immut_data(session: *const Session,
                                                 user_data: *mut c_void,
                                                 o_cb: unsafe extern "C" fn(*mut c_void,
                                                                            int32_t,
-                                                                           DataIdHandle))
-                                                -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                           DataIdHandle)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let xor_id = XorName(*id);
         let data_id = DataIdentifier::Immutable(xor_id);
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |_, obj_cache| {
+        (*session).send(move |_, obj_cache| {
             let handle = obj_cache.insert_data_id(data_id);
             o_cb(user_data.0, 0, handle);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -77,9 +75,8 @@ pub unsafe extern "C" fn data_id_new_appendable_data(session: *const Session,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
                                                                                 int32_t,
-                                                                                DataIdHandle))
-                                                     -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                                DataIdHandle)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let xor_id = XorName(*id);
         let data_id = if is_private {
             DataIdentifier::PrivAppendable(xor_id)
@@ -89,12 +86,11 @@ pub unsafe extern "C" fn data_id_new_appendable_data(session: *const Session,
 
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |_, obj_cache| {
+        (*session).send(move |_, obj_cache| {
             let handle = obj_cache.insert_data_id(data_id);
             o_cb(user_data.0, 0, handle);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -151,24 +147,21 @@ mod tests {
             data_id_new_struct_data(sess_ptr, type_tag, &struct_id_arr, tx, data_id_cb);
             data_id_handle_struct = unwrap!(rx.recv());
 
-            assert_eq!(data_id_new_immut_data(sess_ptr, &immut_id_arr, tx, data_id_cb),
-                       0);
+            data_id_new_immut_data(sess_ptr, &immut_id_arr, tx, data_id_cb);
             data_id_handle_immut = unwrap!(rx.recv());
 
-            assert_eq!(data_id_new_appendable_data(sess_ptr,
-                                                   &priv_app_id_arr,
-                                                   true,
-                                                   tx,
-                                                   data_id_cb),
-                       0);
+            data_id_new_appendable_data(sess_ptr,
+                                        &priv_app_id_arr,
+                                        true,
+                                        tx,
+                                        data_id_cb);
             data_id_handle_priv_appendable = unwrap!(rx.recv());
 
-            assert_eq!(data_id_new_appendable_data(sess_ptr,
-                                                   &pub_app_id_arr,
-                                                   false,
-                                                   tx,
-                                                   data_id_cb),
-                       0);
+            data_id_new_appendable_data(sess_ptr,
+                                        &pub_app_id_arr,
+                                        false,
+                                        tx,
+                                        data_id_cb);
             data_id_handle_pub_appendable = unwrap!(rx.recv());
         }
 

--- a/src/ffi/low_level_api/immut_data.rs
+++ b/src/ffi/low_level_api/immut_data.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn immut_data_new_self_encryptor(session: *const Session,
                                                                                   SEWriterHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |client, obj_cache| {
             let mut se_storage = Box::new(SelfEncryptionStorage::new(client.clone()));
             let obj_cache = obj_cache.clone();
@@ -80,8 +80,7 @@ pub unsafe extern "C" fn immut_data_new_self_encryptor(session: *const Session,
 
             Some(fut)
         })
-    },
-                    move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 /// Write to Self Encryptor
@@ -95,7 +94,7 @@ pub unsafe extern "C" fn immut_data_write_to_self_encryptor(session: *const Sess
                                                                                        int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         let data_slice = slice::from_raw_parts(data, size);
 
         (*session).send(move |_, obj_cache| {
@@ -116,8 +115,7 @@ pub unsafe extern "C" fn immut_data_write_to_self_encryptor(session: *const Sess
                 .into_box();
             Some(fut)
         })
-    },
-                    move |err| o_cb(user_data.0, ffi_error_code!(err)));
+    });
 }
 
 /// Close Self Encryptor
@@ -132,7 +130,7 @@ pub unsafe extern "C" fn immut_data_close_self_encryptor(session: *const Session
                                                                                     DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |client, obj_cache| {
             let fut = {
                 match obj_cache.remove_se_writer(se_h) {
@@ -188,8 +186,7 @@ pub unsafe extern "C" fn immut_data_close_self_encryptor(session: *const Session
 
             Some(fut)
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e), 0));
+    });
 }
 
 /// Fetch Self Encryptor
@@ -204,7 +201,7 @@ pub unsafe extern "C" fn immut_data_fetch_self_encryptor(session: *const Session
                                                              SEReaderHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |client, obj_cache| {
             let c2 = client.clone();
             let c3 = client.clone();
@@ -266,8 +263,7 @@ pub unsafe extern "C" fn immut_data_fetch_self_encryptor(session: *const Session
                 .into_box();
             Some(fut)
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e), 0));
+    });
 }
 
 /// Get data size from Self Encryptor
@@ -278,7 +274,7 @@ pub unsafe extern "C" fn immut_data_size(session: *const Session,
                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t, u64)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             match obj_cache.get_se_reader(se_h) {
                 Ok(se_wrapper) => {
@@ -290,8 +286,7 @@ pub unsafe extern "C" fn immut_data_size(session: *const Session,
             };
             None
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e), 0));
+    });
 }
 
 /// Read from Self Encryptor
@@ -309,7 +304,7 @@ pub unsafe extern "C" fn immut_data_read_from_self_encryptor(session: *const Ses
                                                                                         size_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let mut se_wrapper = match obj_cache.get_se_reader(se_h) {
                 Ok(r) => r,
@@ -345,8 +340,7 @@ pub unsafe extern "C" fn immut_data_read_from_self_encryptor(session: *const Ses
 
             Some(fut)
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e), ptr::null_mut(), 0, 0));
+    });
 }
 
 /// Free Self Encryptor Writer handle
@@ -359,14 +353,13 @@ pub unsafe extern "C" fn immut_data_self_encryptor_writer_free(session: *const S
                                                                              int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let res = obj_cache.remove_se_writer(handle);
             o_cb(user_data.0, ffi_result_code!(res));
             None
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e)));
+    });
 }
 
 /// Free Self Encryptor Reader handle
@@ -379,14 +372,13 @@ pub unsafe extern "C" fn immut_data_self_encryptor_reader_free(session: *const S
                                                                              int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let res = obj_cache.remove_se_reader(handle);
             o_cb(user_data.0, ffi_result_code!(res));
             None
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e)))
+    })
 }
 
 #[cfg(test)]

--- a/src/ffi/low_level_api/misc.rs
+++ b/src/ffi/low_level_api/misc.rs
@@ -37,14 +37,13 @@ pub unsafe extern "C" fn misc_encrypt_key_free(session: *const Session,
                                                o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let res = obj_cache.remove_encrypt_key(handle);
             o_cb(user_data.0, ffi_result_code!(res));
             None
         })
-    },
-                            move |e| o_cb(user_data.0, ffi_error_code!(e)))
+    })
 }
 
 /// Free Sign Key handle
@@ -55,14 +54,13 @@ pub unsafe extern "C" fn misc_sign_key_free(session: *const Session,
                                             o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             let res = obj_cache.remove_sign_key(handle);
             o_cb(user_data.0, ffi_result_code!(res));
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err)));
+    });
 }
 
 /// Serialise sign::PubKey
@@ -77,7 +75,7 @@ pub unsafe extern "C" fn misc_serialise_sign_key(session: *const Session,
                                                                             size_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             match misc_serialise_sign_key_impl(obj_cache, sign_key_h) {
                 Ok(mut ser_sign_key) => {
@@ -91,10 +89,7 @@ pub unsafe extern "C" fn misc_serialise_sign_key(session: *const Session,
             }
             None
         })
-    },
-                            move |err| {
-                                o_cb(user_data.0, ffi_error_code!(err), ptr::null_mut(), 0, 0)
-                            });
+    });
 }
 
 fn misc_serialise_sign_key_impl(obj_cache: &ObjectCache,
@@ -114,7 +109,7 @@ pub unsafe extern "C" fn misc_deserialise_sign_key(session: *const Session,
                                                                               SignKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let data = OpaqueCtx(data as *mut _);
 
         (*session).send(move |_, obj_cache| {
@@ -130,8 +125,7 @@ pub unsafe extern "C" fn misc_deserialise_sign_key(session: *const Session,
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 /// Get MAID-sign::PubKey
@@ -143,7 +137,7 @@ pub unsafe extern "C" fn misc_maid_sign_key(session: *const Session,
                                                                        SignKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |client, obj_cache| {
             let sign_key = match client.public_signing_key() {
                 Ok(sign_key) => sign_key,
@@ -156,8 +150,7 @@ pub unsafe extern "C" fn misc_maid_sign_key(session: *const Session,
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 /// Serialise DataIdentifier
@@ -173,7 +166,7 @@ pub unsafe extern "C" fn misc_serialise_data_id(session: *const Session,
                                                                            size_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             match misc_serialise_data_id_impl(obj_cache, data_id_h) {
                 Ok(mut ser_data_id) => {
@@ -190,10 +183,7 @@ pub unsafe extern "C" fn misc_serialise_data_id(session: *const Session,
             }
             None
         })
-    },
-                            move |err| {
-                                o_cb(user_data.0, ffi_error_code!(err), ptr::null_mut(), 0, 0)
-                            });
+    });
 }
 
 fn misc_serialise_data_id_impl(obj_cache: &ObjectCache,
@@ -213,7 +203,7 @@ pub unsafe extern "C" fn misc_deserialise_data_id(session: *const Session,
                                                                              DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let data = OpaqueCtx(data as *mut _);
 
         (*session).send(move |_, obj_cache| {
@@ -231,8 +221,7 @@ pub unsafe extern "C" fn misc_deserialise_data_id(session: *const Session,
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 /// Serialise AppendableData
@@ -247,7 +236,7 @@ pub unsafe extern "C" fn misc_serialise_appendable_data(session: *const Session,
                                                                                    size_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             match serialise_appendable_data_impl(obj_cache, ad_h) {
                 Ok(mut ser_ad) => {
@@ -261,10 +250,7 @@ pub unsafe extern "C" fn misc_serialise_appendable_data(session: *const Session,
             }
             None
         })
-    },
-                            move |e| {
-                                o_cb(user_data.0, ffi_error_code!(e), ptr::null_mut(), 0, 0)
-                            });
+    });
 }
 
 fn serialise_appendable_data_impl(object_cache: &ObjectCache,
@@ -287,7 +273,7 @@ pub unsafe extern "C" fn misc_deserialise_appendable_data(session: *const Sessio
                                                                                      ADHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let data = OpaqueCtx(data as *mut _);
 
         (*session).send(move |_, obj_cache| {
@@ -298,8 +284,7 @@ pub unsafe extern "C" fn misc_deserialise_appendable_data(session: *const Sessio
             }
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 fn deserialise_appendable_data_impl(obj_cache: &ObjectCache,
@@ -327,7 +312,7 @@ pub unsafe extern "C" fn misc_serialise_struct_data(session: *const Session,
                                                                                size_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         (*session).send(move |_, obj_cache| {
             match misc_serialise_struct_data_impl(obj_cache, sd_h) {
                 Ok(mut ser_sd) => {
@@ -342,10 +327,7 @@ pub unsafe extern "C" fn misc_serialise_struct_data(session: *const Session,
             }
             None
         })
-    },
-                            move |err| {
-                                o_cb(user_data.0, ffi_error_code!(err), ptr::null_mut(), 0, 0)
-                            });
+    });
 }
 
 fn misc_serialise_struct_data_impl(obj_cache: &ObjectCache,
@@ -366,7 +348,7 @@ pub unsafe extern "C" fn misc_deserialise_struct_data(session: *const Session,
                                                          StructDataHandle)) {
     let user_data = OpaqueCtx(user_data);
 
-    helper::catch_unwind_cb(|| {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         let data = OpaqueCtx(data as *mut _);
 
         (*session).send(move |_, obj_cache| {
@@ -382,8 +364,7 @@ pub unsafe extern "C" fn misc_deserialise_struct_data(session: *const Session,
             o_cb(user_data.0, 0, handle);
             None
         })
-    },
-                            move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 

--- a/src/ffi/low_level_api/misc.rs
+++ b/src/ffi/low_level_api/misc.rs
@@ -382,17 +382,16 @@ pub unsafe extern "C" fn misc_u8_ptr_free(ptr: *mut u8, size: usize, capacity: u
 #[no_mangle]
 pub unsafe extern "C" fn misc_object_cache_reset(session: *const Session,
                                                  user_data: *mut c_void,
-                                                 o_cb: unsafe extern "C" fn(*mut c_void, int32_t))
-                                                 -> i32 {
+                                                 o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    ffi_try!((*session).send(move |_, obj_cache| {
-        obj_cache.reset();
-        o_cb(user_data.0, 0);
-        None
-    }));
-
-    0
+    helper::catch_unwind_cb(user_data, o_cb, || {
+        (*session).send(move |_, obj_cache| {
+            obj_cache.reset();
+            o_cb(user_data.0, 0);
+            None
+        })
+    })
 }
 
 #[cfg(test)]

--- a/src/ffi/macros.rs
+++ b/src/ffi/macros.rs
@@ -39,29 +39,6 @@ macro_rules! ffi_result_code {
     }
 }
 
-macro_rules! ffi_try {
-    ($result:expr) => {
-        match $result {
-            Ok(value)  => value,
-            Err(error) => {
-                return ffi_error_code!(error)
-            },
-        }
-    }
-}
-
-macro_rules! ffi_ptr_try {
-    ($result:expr, $out:expr) => {
-        match $result {
-            Ok(value)  => value,
-            Err(error) => {
-                let _ = ffi_error_code!(error);
-                return ::std::ptr::null();
-            },
-        }
-    }
-}
-
 macro_rules! try_cb {
     ($result:expr, $user_data:expr, $cb:expr) => {
         match $result {

--- a/src/ffi/macros.rs
+++ b/src/ffi/macros.rs
@@ -61,3 +61,16 @@ macro_rules! ffi_ptr_try {
         }
     }
 }
+
+macro_rules! try_cb {
+    ($result:expr, $user_data:expr, $cb:expr) => {
+        match $result {
+            Ok(value) => value,
+            Err(err) => {
+                use $crate::ffi::callback::{Callback, CallbackArgs};
+                $cb.call($user_data.into(), ffi_error_code!(err), CallbackArgs::default());
+                return None;
+            }
+        }
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -57,6 +57,7 @@ pub mod nfs;
 pub mod session;
 pub mod string_list;
 
+mod callback;
 mod config;
 mod helper;
 mod launcher_config;
@@ -69,14 +70,21 @@ pub use ffi::errors::FfiError;
 pub use ffi::session::Session;
 
 use futures::Future;
+use libc::c_void;
 
 /// Helper type to represent the FFI future result
 pub type FfiFuture<T> = Future<Item = T, Error = FfiError>;
 
 /// Type that holds opaque user data handed into FFI functions
 #[derive(Clone, Copy)]
-pub struct OpaqueCtx(*mut ::libc::c_void);
+pub struct OpaqueCtx(*mut c_void);
 unsafe impl Send for OpaqueCtx {}
+
+impl Into<*mut c_void> for OpaqueCtx {
+    fn into(self) -> *mut c_void {
+       self.0
+    }
+}
 
 /// Result that uses FfiError as error type
 pub type FfiResult<T> = Result<T, FfiError>;

--- a/src/ffi/nfs/dir.rs
+++ b/src/ffi/nfs/dir.rs
@@ -44,16 +44,15 @@ pub unsafe extern "C" fn nfs_create_dir(session: *const Session,
                                         is_private: bool,
                                         is_shared: bool,
                                         user_data: *mut c_void,
-                                        o_cb: extern "C" fn(*mut c_void, int32_t))
-                                        -> int32_t {
-    helper::catch_unwind_i32(|| {
+                                        o_cb: extern "C" fn(*mut c_void, int32_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI create directory, given the path.");
 
-        let dir_path = ffi_try!(helper::c_utf8_to_str(dir_path, dir_path_len));
+        let dir_path = try!(helper::c_utf8_to_str(dir_path, dir_path_len));
         let user_metadata = slice::from_raw_parts(user_metadata, user_metadata_len);
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |client, obj_cache| {
+        (*session).send(move |client, obj_cache| {
             match obj_cache.get_app(app_handle) {
                 Ok(app) => {
                     let fut = create_dir(&client,
@@ -71,9 +70,7 @@ pub unsafe extern "C" fn nfs_create_dir(session: *const Session,
                     None
                 }
             }
-        }));
-
-        0
+        })
     })
 }
 
@@ -85,14 +82,13 @@ pub unsafe extern "C" fn nfs_delete_dir(session: *const Session,
                                         dir_path_len: usize,
                                         is_shared: bool,
                                         user_data: *mut c_void,
-                                        o_cb: unsafe extern "C" fn(*mut c_void, int32_t))
-                                        -> int32_t {
-    helper::catch_unwind_i32(|| {
+                                        o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI delete dir, given the path.");
-        let dir_path = ffi_try!(helper::c_utf8_to_str(dir_path, dir_path_len));
+        let dir_path = try!(helper::c_utf8_to_str(dir_path, dir_path_len));
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |client, obj_cache| {
+        (*session).send(move |client, obj_cache| {
             match obj_cache.get_app(app_handle) {
                 Ok(app) => {
                     delete_dir(&client, &app, dir_path, is_shared)
@@ -105,9 +101,7 @@ pub unsafe extern "C" fn nfs_delete_dir(session: *const Session,
                     None
                 }
             }
-        }));
-
-        0
+        })
     })
 }
 
@@ -121,14 +115,13 @@ pub unsafe extern "C" fn nfs_get_dir(session: *const Session,
                                      user_data: *mut c_void,
                                      o_cb: extern "C" fn(*mut c_void,
                                                          int32_t,
-                                                         details_handle: *mut DirDetails))
-                                     -> int32_t {
-    helper::catch_unwind_i32(|| {
+                                                         details_handle: *mut DirDetails)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get dir, given the path.");
-        let dir_path = ffi_try!(helper::c_utf8_to_str(dir_path, dir_path_len));
+        let dir_path = try!(helper::c_utf8_to_str(dir_path, dir_path_len));
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |client, obj_cache| {
+        (*session).send(move |client, obj_cache| {
             match obj_cache.get_app(app_handle) {
                 Ok(app) => {
                     get_dir(&client, &app, dir_path, is_shared)
@@ -147,9 +140,7 @@ pub unsafe extern "C" fn nfs_get_dir(session: *const Session,
                     None
                 }
             }
-        }));
-
-        0
+        })
     })
 }
 
@@ -165,17 +156,16 @@ pub unsafe extern "C" fn nfs_modify_dir(session: *const Session,
                                         new_user_metadata: *const u8,
                                         new_user_metadata_len: usize,
                                         user_data: *mut c_void,
-                                        o_cb: extern "C" fn(*mut c_void, int32_t))
-                                        -> int32_t {
-    helper::catch_unwind_i32(|| {
+                                        o_cb: extern "C" fn(*mut c_void, int32_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI modify directory, given the path.");
-        let dir_path = ffi_try!(helper::c_utf8_to_str(dir_path, dir_path_len));
-        let new_name = ffi_try!(helper::c_utf8_to_opt_string(new_name, new_name_len));
+        let dir_path = try!(helper::c_utf8_to_str(dir_path, dir_path_len));
+        let new_name = try!(helper::c_utf8_to_opt_string(new_name, new_name_len));
         let new_user_metadata = helper::u8_ptr_to_opt_vec(new_user_metadata, new_user_metadata_len);
 
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |client, obj_cache| {
+        (*session).send(move |client, obj_cache| {
             match obj_cache.get_app(app_handle) {
                 Ok(app) => {
                     modify_dir(&client,
@@ -193,9 +183,7 @@ pub unsafe extern "C" fn nfs_modify_dir(session: *const Session,
                     None
                 }
             }
-        }));
-
-        0
+        })
     })
 }
 
@@ -211,16 +199,15 @@ pub unsafe extern "C" fn nfs_move_dir(session: *const Session,
                                       is_dst_path_shared: bool,
                                       retain_src: bool,
                                       user_data: *mut c_void,
-                                      o_cb: unsafe extern "C" fn(*mut c_void, int32_t))
-                                      -> int32_t {
-    helper::catch_unwind_i32(|| {
+                                      o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI move directory, from {:?} to {:?}.", src_path, dst_path);
 
-        let src_path = ffi_try!(helper::c_utf8_to_str(src_path, src_path_len));
-        let dst_path = ffi_try!(helper::c_utf8_to_str(dst_path, dst_path_len));
+        let src_path = try!(helper::c_utf8_to_str(src_path, src_path_len));
+        let dst_path = try!(helper::c_utf8_to_str(dst_path, dst_path_len));
         let user_data = OpaqueCtx(user_data);
 
-        ffi_try!((*session).send(move |client, obj_cache| {
+        (*session).send(move |client, obj_cache| {
             match obj_cache.get_app(app_handle) {
                 Ok(app) => {
                     move_dir(&client,
@@ -239,8 +226,7 @@ pub unsafe extern "C" fn nfs_move_dir(session: *const Session,
                     None
                 }
             }
-        }));
-        0
+        })
     })
 }
 

--- a/src/ffi/nfs/file.rs
+++ b/src/ffi/nfs/file.rs
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn nfs_delete_file(session: *const Session,
                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI delete file, given the path.");
         let file_path = try!(helper::c_utf8_to_str(file_path, file_path_len));
 
@@ -67,8 +67,7 @@ pub unsafe extern "C" fn nfs_delete_file(session: *const Session,
                 }
             }
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e)))
+    })
 }
 
 /// Get file. The returned FileDetails pointer must be disposed of by calling
@@ -88,7 +87,7 @@ pub unsafe extern "C" fn nfs_get_file(session: *const Session,
                                                                  *mut FileDetails)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get file, given the path.");
 
         let file_path = try!(helper::c_utf8_to_str(file_path, file_path_len));
@@ -119,8 +118,7 @@ pub unsafe extern "C" fn nfs_get_file(session: *const Session,
                 }
             }
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e), ptr::null_mut()))
+    })
 }
 
 /// Modify name, metadata or content of the file.
@@ -140,7 +138,7 @@ pub unsafe extern "C" fn nfs_modify_file(session: *const Session,
                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI modify file, given the path.");
 
         let file_path = try!(helper::c_utf8_to_str(file_path, file_path_len));
@@ -171,8 +169,7 @@ pub unsafe extern "C" fn nfs_modify_file(session: *const Session,
                 }
             }
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e)))
+    })
 }
 
 /// Move or copy a file.
@@ -190,7 +187,7 @@ pub unsafe extern "C" fn nfs_move_file(session: *const Session,
                                        o_cb: extern "C" fn(*mut c_void, int32_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI move file, from {:?} to {:?}.", src_path, dst_path);
 
         let src_path = try!(helper::c_utf8_to_str(src_path, src_path_len));
@@ -219,8 +216,7 @@ pub unsafe extern "C" fn nfs_move_file(session: *const Session,
                 }
             }
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e)))
+    })
 }
 
 /// Get a number of file versions
@@ -236,7 +232,7 @@ pub unsafe extern "C" fn nfs_get_file_num_of_versions(session: *const Session,
                                                                           uint64_t)) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get number of file versions, given the path.");
 
         let file_path = try!(helper::c_utf8_to_str(file_path, file_path_len));
@@ -256,8 +252,7 @@ pub unsafe extern "C" fn nfs_get_file_num_of_versions(session: *const Session,
                 }
             }
         })
-    },
-                    move |err| o_cb(user_data.0, ffi_error_code!(err), 0));
+    });
 }
 
 fn get_num_of_versions(client: &Client,
@@ -290,7 +285,7 @@ pub unsafe extern "C" fn nfs_get_file_metadata(session: *const Session,
                                                                    int32_t,
                                                                    *mut FileMetadata)) {
     let user_data = OpaqueCtx(user_data);
-    catch_unwind_cb(|| {
+    catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get file metadata, given the path.");
 
         let file_path = try!(helper::c_utf8_to_str(file_path, file_path_len));
@@ -315,8 +310,7 @@ pub unsafe extern "C" fn nfs_get_file_metadata(session: *const Session,
                 }
             }
         })
-    },
-                    move |e| o_cb(user_data.0, ffi_error_code!(e), ptr::null_mut()))
+    })
 }
 
 fn delete_file(client: &Client, app: &App, file_path: &str, is_shared: bool) -> Box<FfiFuture<()>> {

--- a/src/ffi/session.rs
+++ b/src/ffi/session.rs
@@ -331,16 +331,14 @@ pub unsafe extern "C" fn client_issued_gets(session: *const Session,
                                             user_data: *mut c_void,
                                             o_cb: unsafe extern "C" fn(*mut c_void,
                                                                        int32_t,
-                                                                       int64_t))
-                                            -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                       int64_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI retrieve client issued GETs.");
         let user_data = OpaqueCtx(user_data);
-        ffi_try!((*session).send(move |client, _| {
+        (*session).send(move |client, _| {
             o_cb(user_data.0, 0, client.issued_gets() as int64_t);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -350,16 +348,14 @@ pub unsafe extern "C" fn client_issued_puts(session: *const Session,
                                             user_data: *mut c_void,
                                             o_cb: unsafe extern "C" fn(*mut c_void,
                                                                        int32_t,
-                                                                       int64_t))
-                                            -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                       int64_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI retrieve client issued PUTs.");
         let user_data = OpaqueCtx(user_data);
-        ffi_try!((*session).send(move |client, _| {
+        (*session).send(move |client, _| {
             o_cb(user_data.0, 0, client.issued_puts() as int64_t);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -367,18 +363,16 @@ pub unsafe extern "C" fn client_issued_puts(session: *const Session,
 #[no_mangle]
 pub unsafe extern "C" fn client_issued_posts(session: *const Session,
                                              user_data: *mut c_void,
-                                             o_cb: unsafe extern "C" fn(int32_t,
-                                                                        *mut c_void,
-                                                                        int64_t))
-                                             -> i32 {
-    helper::catch_unwind_i32(|| {
+                                             o_cb: unsafe extern "C" fn(*mut c_void,
+                                                                        int32_t,
+                                                                        int64_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI retrieve client issued POSTs.");
         let user_data = OpaqueCtx(user_data);
-        ffi_try!((*session).send(move |client, _| {
-            o_cb(0, user_data.0, client.issued_posts() as int64_t);
+        (*session).send(move |client, _| {
+            o_cb(user_data.0, 0, client.issued_posts() as int64_t);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -388,16 +382,14 @@ pub unsafe extern "C" fn client_issued_deletes(session: *const Session,
                                                user_data: *mut c_void,
                                                o_cb: unsafe extern "C" fn(*mut c_void,
                                                                           int32_t,
-                                                                          int64_t))
-                                               -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                          int64_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI retrieve client issued DELETEs.");
         let user_data = OpaqueCtx(user_data);
-        ffi_try!((*session).send(move |client, _| {
+        (*session).send(move |client, _| {
             o_cb(user_data.0, 0, client.issued_deletes() as int64_t);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -407,16 +399,14 @@ pub unsafe extern "C" fn client_issued_appends(session: *const Session,
                                                user_data: *mut c_void,
                                                o_cb: unsafe extern "C" fn(*mut c_void,
                                                                           int32_t,
-                                                                          int64_t))
-                                               -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                          int64_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI retrieve client issued APPENDs.");
         let user_data = OpaqueCtx(user_data);
-        ffi_try!((*session).send(move |client, _| {
+        (*session).send(move |client, _| {
             o_cb(user_data.0, 0, client.issued_appends() as int64_t);
             None
-        }));
-        0
+        })
     })
 }
 
@@ -429,13 +419,11 @@ pub unsafe extern "C" fn get_account_info(session: *const Session,
                                           o_cb: unsafe extern "C" fn(*mut c_void,
                                                                      int32_t,
                                                                      uint64_t,
-                                                                     uint64_t))
-                                          -> i32 {
-    helper::catch_unwind_i32(|| {
+                                                                     uint64_t)) {
+    helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get account information.");
         let user_data = OpaqueCtx(user_data);
-        ffi_try!((*session).account_info(user_data, o_cb));
-        0
+        (*session).account_info(user_data, o_cb)
     })
 }
 

--- a/src/ffi/session.rs
+++ b/src/ffi/session.rs
@@ -247,14 +247,14 @@ pub unsafe extern "C" fn create_unregistered_client(user_data: *mut c_void,
     helper::catch_unwind_i32(|| {
         trace!("FFI create unregistered client.");
         let user_data = OpaqueCtx(user_data);
-        let session = ffi_try!(Session::unregistered(move |net_event| {
+        let session = try!(Session::unregistered(move |net_event| {
             match net_event {
                 Ok(event) => obs_cb(user_data.0, 0, event.into()),
                 Err(e) => obs_cb(user_data.0, ffi_error_code!(e), 0),
             }
         }));
         *session_handle = Box::into_raw(Box::new(session));
-        0
+        Ok(())
     })
 }
 
@@ -276,11 +276,11 @@ pub unsafe extern "C" fn create_account(account_locator: *const u8,
     helper::catch_unwind_i32(|| {
         trace!("FFI create a client account.");
 
-        let acc_locator = ffi_try!(helper::c_utf8_to_str(account_locator, account_locator_len));
-        let acc_password = ffi_try!(helper::c_utf8_to_str(account_password, account_password_len));
+        let acc_locator = try!(helper::c_utf8_to_str(account_locator, account_locator_len));
+        let acc_password = try!(helper::c_utf8_to_str(account_password, account_password_len));
         let user_data = OpaqueCtx(user_data);
         let session =
-            ffi_try!(Session::create_account(acc_locator, acc_password, move |net_event| {
+            try!(Session::create_account(acc_locator, acc_password, move |net_event| {
                 match net_event {
                     Ok(event) => o_network_obs_cb(user_data.0, 0, event.into()),
                     Err(e) => o_network_obs_cb(user_data.0, ffi_error_code!(e), 0),
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn create_account(account_locator: *const u8,
             }));
 
         *session_handle = Box::into_raw(Box::new(session));
-        0
+        Ok(())
     })
 }
 
@@ -310,10 +310,10 @@ pub unsafe extern "C" fn log_in(account_locator: *const u8,
     helper::catch_unwind_i32(|| {
         trace!("FFI login a registered client.");
 
-        let acc_locator = ffi_try!(helper::c_utf8_to_str(account_locator, account_locator_len));
-        let acc_password = ffi_try!(helper::c_utf8_to_str(account_password, account_password_len));
+        let acc_locator = try!(helper::c_utf8_to_str(account_locator, account_locator_len));
+        let acc_password = try!(helper::c_utf8_to_str(account_password, account_password_len));
         let user_data = OpaqueCtx(user_data);
-        let session = ffi_try!(Session::log_in(acc_locator, acc_password, move |net_event| {
+        let session = try!(Session::log_in(acc_locator, acc_password, move |net_event| {
             match net_event {
                 Ok(event) => o_network_obs_cb(user_data.0, 0, event.into()),
                 Err(e) => o_network_obs_cb(user_data.0, ffi_error_code!(e), 0),
@@ -321,7 +321,7 @@ pub unsafe extern "C" fn log_in(account_locator: *const u8,
         }));
 
         *session_handle = Box::into_raw(Box::new(session));
-        0
+        Ok(())
     })
 }
 

--- a/src/ffi/session.rs
+++ b/src/ffi/session.rs
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn create_unregistered_client(user_data: *mut c_void,
                                                                                  int32_t),
                                                     session_handle: *mut *mut Session)
                                                     -> int32_t {
-    helper::catch_unwind_i32(|| {
+    helper::catch_unwind_error_code(|| {
         trace!("FFI create unregistered client.");
         let user_data = OpaqueCtx(user_data);
         let session = try!(Session::unregistered(move |net_event| {
@@ -273,7 +273,7 @@ pub unsafe extern "C" fn create_account(account_locator: *const u8,
                                                                                int32_t,
                                                                                int32_t))
                                         -> int32_t {
-    helper::catch_unwind_i32(|| {
+    helper::catch_unwind_error_code(|| {
         trace!("FFI create a client account.");
 
         let acc_locator = try!(helper::c_utf8_to_str(account_locator, account_locator_len));
@@ -307,7 +307,7 @@ pub unsafe extern "C" fn log_in(account_locator: *const u8,
                                                                        int32_t,
                                                                        int32_t))
                                 -> int32_t {
-    helper::catch_unwind_i32(|| {
+    helper::catch_unwind_error_code(|| {
         trace!("FFI login a registered client.");
 
         let acc_locator = try!(helper::c_utf8_to_str(account_locator, account_locator_len));


### PR DESCRIPTION
- use  `catch_unwind_cb` everywhere where appropriate
- make `catch_unwind_cb` more ergonomic
- introduce `try_cb` macro (like `try`, but calls the callback on error)
- fix order of callback arguments (user data first, error code second) in few odd places
- remove `ffi_try` and `ffi_try_ptr` macros (not needed anymore)