### PR TITLE
chore/deps: remove redundant libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ clippy = { version = "~0.0.97", optional = true }
 config_file_handler = "~0.4.0"
 futures = "~0.1.3"
 lazy_static = "~0.2.1"
-libc = "~0.2.17"
 log = "~0.3.6"
 lru-cache = "~0.1.0"
 maidsafe_utilities = "~0.10.0"

--- a/examples/email.rs
+++ b/examples/email.rs
@@ -46,11 +46,9 @@ extern crate maidsafe_utilities;
 #[macro_use]
 extern crate unwrap;
 
-extern crate libc;
 extern crate rust_sodium;
 extern crate safe_core;
 
-use libc::c_void;
 use rust_sodium::crypto::hash::sha256::{self, Digest};
 use safe_core::ffi::AppHandle;
 use safe_core::ffi::app::*;
@@ -60,6 +58,7 @@ use safe_core::ffi::low_level_api::data_id::*;
 use safe_core::ffi::low_level_api::immut_data::*;
 use safe_core::ffi::low_level_api::misc::*;
 use safe_core::ffi::session::*;
+use std::os::raw::c_void;
 use std::ptr;
 use std::sync::mpsc::{self, Sender};
 

--- a/examples/email_stress_test.rs
+++ b/examples/email_stress_test.rs
@@ -48,14 +48,12 @@ extern crate unwrap;
 
 extern crate crossbeam;
 extern crate docopt;
-extern crate libc;
 extern crate rand;
 extern crate rust_sodium;
 extern crate rustc_serialize;
 extern crate safe_core;
 
 use docopt::Docopt;
-use libc::c_void;
 use rand::{Rng, SeedableRng, XorShiftRng};
 use rust_sodium::crypto::hash::sha256::{self, Digest};
 use safe_core::ffi::{AppHandle, AppendableDataHandle, CipherOptHandle};
@@ -67,6 +65,7 @@ use safe_core::ffi::low_level_api::data_id::*;
 use safe_core::ffi::low_level_api::immut_data::*;
 use safe_core::ffi::low_level_api::misc::*;
 use safe_core::ffi::session::*;
+use std::os::raw::c_void;
 use std::ptr;
 use std::sync::Mutex;
 use std::sync::mpsc::{self, Sender};

--- a/src/ffi/app.rs
+++ b/src/ffi/app.rs
@@ -29,9 +29,9 @@
 use core::{Client, FutureExt};
 use ffi::{AppHandle, FfiError, FfiFuture, OpaqueCtx, Session, helper, launcher_config};
 use futures::{self, Future};
-use libc::{c_void, int32_t};
 use nfs::DirId;
 use rust_sodium::crypto::{box_, secretbox};
+use std::os::raw::c_void;
 
 /// Represents an application connected to the launcher.
 #[derive(RustcEncodable, RustcDecodable, Debug, Clone)]
@@ -112,7 +112,7 @@ pub unsafe extern "C" fn register_app(session: *mut Session,
                                       vendor_len: usize,
                                       safe_drive_access: bool,
                                       user_data: *mut c_void,
-                                      o_cb: unsafe extern "C" fn(*mut c_void, int32_t, AppHandle)) {
+                                      o_cb: unsafe extern "C" fn(*mut c_void, i32, AppHandle)) {
     let user_data = OpaqueCtx(user_data);
 
     let _ = helper::catch_unwind_cb(user_data, o_cb, || {
@@ -139,9 +139,7 @@ pub unsafe extern "C" fn register_app(session: *mut Session,
 #[no_mangle]
 pub unsafe extern "C" fn create_unregistered_app(session: *mut Session,
                                                  user_data: *mut c_void,
-                                                 o_cb: extern "C" fn(*mut c_void,
-                                                                     int32_t,
-                                                                     AppHandle)) {
+                                                 o_cb: extern "C" fn(*mut c_void, i32, AppHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
         (*session).send(move |_, object_cache| {

--- a/src/ffi/callback.rs
+++ b/src/ffi/callback.rs
@@ -21,72 +21,73 @@
 
 //! Helpers to work with extern "C" callbacks.
 
-use libc::{c_void, int32_t};
+use std::os::raw::c_void;
 use std::ptr;
 
 // This trait allows us to treat callbacks with different number and type of
 // arguments uniformly.
 pub trait Callback {
     type Args: CallbackArgs;
-    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args);
+    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args);
 }
 
-// TODO: remove the impls for unsafe fn's (after we decide all callbacks should be safe).
+// TODO: remove the impls for unsafe fn's (after we decide all callbacks should
+// be safe).
 
-impl Callback for extern "C" fn(*mut c_void, int32_t) {
+impl Callback for extern "C" fn(*mut c_void, i32) {
     type Args = ();
-    fn call(&self, user_data: *mut c_void, error: int32_t, _args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: i32, _args: Self::Args) {
         self(user_data, error)
     }
 }
 
-impl Callback for unsafe extern "C" fn(*mut c_void, int32_t) {
+impl Callback for unsafe extern "C" fn(*mut c_void, i32) {
     type Args = ();
-    fn call(&self, user_data: *mut c_void, error: int32_t, _args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: i32, _args: Self::Args) {
         unsafe { self(user_data, error) }
     }
 }
 
-impl<T: CallbackArgs> Callback for extern "C" fn(*mut c_void, int32_t, a: T) {
+impl<T: CallbackArgs> Callback for extern "C" fn(*mut c_void, i32, a: T) {
     type Args = T;
-    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
         self(user_data, error, args)
     }
 }
 
-impl<T: CallbackArgs> Callback for unsafe extern "C" fn(*mut c_void, int32_t, a: T) {
+impl<T: CallbackArgs> Callback for unsafe extern "C" fn(*mut c_void, i32, a: T) {
     type Args = T;
-    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
         unsafe { self(user_data, error, args) }
     }
 }
 
 impl<T0: CallbackArgs, T1: CallbackArgs> Callback
-    for unsafe extern "C" fn(*mut c_void, int32_t, a0: T0, a1: T1) {
+    for extern "C" fn(*mut c_void, i32, a0: T0, a1: T1) {
     type Args = (T0, T1);
-    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
-        unsafe { self(user_data, error, args.0, args.1) }
+    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
+        self(user_data, error, args.0, args.1)
     }
 }
 
 impl<T0: CallbackArgs, T1: CallbackArgs, T2: CallbackArgs> Callback
-    for extern "C" fn(*mut c_void, int32_t, a0: T0, a1: T1, a2: T2) {
+    for extern "C" fn(*mut c_void, i32, a0: T0, a1: T1, a2: T2) {
     type Args = (T0, T1, T2);
-    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
         self(user_data, error, args.0, args.1, args.2)
     }
 }
 
 impl<T0: CallbackArgs, T1: CallbackArgs, T2: CallbackArgs> Callback
-    for unsafe extern "C" fn(*mut c_void, int32_t, a0: T0, a1: T1, a2: T2) {
+    for unsafe extern "C" fn(*mut c_void, i32, a0: T0, a1: T1, a2: T2) {
     type Args = (T0, T1, T2);
-    fn call(&self, user_data: *mut c_void, error: int32_t, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
         unsafe { self(user_data, error, args.0, args.1, args.2) }
     }
 }
 
-// This is similar to `Default`, but allows us to implement it for foreign types that
-// don't already implement `Default`.
+// This is similar to `Default`, but allows us to implement it for foreign
+// types that don't already implement `Default`.
 pub trait CallbackArgs {
     fn default() -> Self;
 }

--- a/src/ffi/dns/file.rs
+++ b/src/ffi/dns/file.rs
@@ -27,8 +27,8 @@ use ffi::{FfiError, OpaqueCtx, Session};
 use ffi::file_details::{FileDetails, FileMetadata};
 use ffi::helper;
 use futures::Future;
-use libc::{c_void, int32_t};
 use nfs::helper::dir_helper;
+use std::os::raw::c_void;
 use std::ptr;
 
 /// Get file.
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn dns_get_file(session: *const Session,
                                       length: i64,
                                       include_metadata: bool,
                                       user_data: *mut c_void,
-                                      o_cb: extern "C" fn(*mut c_void, int32_t, *mut FileDetails)) {
+                                      o_cb: extern "C" fn(*mut c_void, i32, *mut FileDetails)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let long_name = try!(helper::c_utf8_to_string(long_name, long_name_len));
         let service_name = try!(helper::c_utf8_to_string(service_name, service_name_len));
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn dns_get_file_metadata(session: *const Session,
                                                file_path_len: usize,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void,
-                                                                   int32_t,
+                                                                   i32,
                                                                    *mut FileMetadata)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let long_name = try!(helper::c_utf8_to_string(long_name, long_name_len));
@@ -141,10 +141,10 @@ mod tests {
     use ffi::file_details::FileDetails;
     use ffi::test_utils;
     use futures::Future;
-    use libc::{c_void, int32_t};
     use nfs::DirId;
     use nfs::helper::{dir_helper, file_helper};
     use rust_sodium::crypto::box_;
+    use std::os::raw::c_void;
     use std::sync::mpsc;
     use super::*;
 
@@ -220,7 +220,7 @@ mod tests {
         let file_name = test_utils::as_raw_parts(&file_name);
 
         extern "C" fn callback(user_data: *mut c_void,
-                               error: int32_t,
+                               error: i32,
                                _file_details_ptr: *mut FileDetails) {
             assert_eq!(error, 0);
             unsafe { test_utils::send_via_user_data(user_data, ()) }

--- a/src/ffi/dns/long_name.rs
+++ b/src/ffi/dns/long_name.rs
@@ -27,8 +27,8 @@ use ffi::{FfiError, OpaqueCtx, Session};
 use ffi::helper;
 use ffi::string_list::{self, StringList};
 use futures::Future;
-use libc::{c_void, int32_t};
 use rust_sodium::crypto::box_;
+use std::os::raw::c_void;
 use std::ptr;
 
 /// Register DNS long name.
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn dns_register_long_name(session: *const Session,
                                                 long_name: *const u8,
                                                 long_name_len: usize,
                                                 user_data: *mut c_void,
-                                                o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                                o_cb: extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let long_name = try!(helper::c_utf8_to_string(long_name, long_name_len));
 
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn dns_delete_long_name(session: *const Session,
                                               long_name: *const u8,
                                               long_name_len: usize,
                                               user_data: *mut c_void,
-                                              o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                              o_cb: extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI delete DNS.");
         let long_name = try!(helper::c_utf8_to_string(long_name, long_name_len));
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn dns_delete_long_name(session: *const Session,
 pub unsafe extern "C" fn dns_get_long_names(session: *const Session,
                                             user_data: *mut c_void,
                                             o_cb: extern "C" fn(*mut c_void,
-                                                                int32_t,
+                                                                i32,
                                                                 *mut StringList)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI Get all dns long names.");
@@ -121,9 +121,9 @@ pub unsafe extern "C" fn dns_get_long_names(session: *const Session,
 mod tests {
     use core::utility;
     use dns::DnsError;
-    use ffi::test_utils;
     use ffi::string_list::*;
-    use libc::{c_void, int32_t};
+    use ffi::test_utils;
+    use std::os::raw::c_void;
     use std::sync::mpsc;
     use super::*;
 
@@ -138,12 +138,12 @@ mod tests {
         {
             let session = test_utils::create_session();
 
-            extern "C" fn register_cb(user_data: *mut c_void, error: int32_t) {
+            extern "C" fn register_cb(user_data: *mut c_void, error: i32) {
                 assert_eq!(error, 0);
                 unsafe { test_utils::send_via_user_data(user_data, ()) }
             }
 
-            extern "C" fn get_cb(user_data: *mut c_void, error: int32_t, list: *mut StringList) {
+            extern "C" fn get_cb(user_data: *mut c_void, error: i32, list: *mut StringList) {
                 assert_eq!(error, 0);
 
                 unsafe {
@@ -174,7 +174,7 @@ mod tests {
         {
             let session = test_utils::create_session();
 
-            extern "C" fn callback(user_data: *mut c_void, error: int32_t) {
+            extern "C" fn callback(user_data: *mut c_void, error: i32) {
                 assert_eq!(error, DnsError::DnsNameAlreadyRegistered.into());
                 unsafe { test_utils::send_via_user_data(user_data, ()) }
             }

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -24,7 +24,6 @@
 use config_file_handler::FileHandler;
 
 use core::CoreError;
-use libc::int32_t;
 use maidsafe_utilities::log as safe_log;
 use std::mem;
 use std::ptr;
@@ -32,7 +31,7 @@ use super::helper;
 
 /// This function should be called to enable logging to a file
 #[no_mangle]
-pub extern "C" fn init_logging() -> int32_t {
+pub extern "C" fn init_logging() -> i32 {
     helper::catch_unwind_error_code(|| {
         Ok(try!(safe_log::init(false).map_err(CoreError::Unexpected)))
     })
@@ -47,17 +46,16 @@ pub unsafe extern "C" fn output_log_path(c_output_file_name: *const u8,
                                          c_ptr: *mut *const u8,
                                          c_size: *mut usize,
                                          c_capacity: *mut usize)
-                                         -> int32_t {
+                                         -> i32 {
     helper::catch_unwind_error_code(|| {
-        let op_file = try!(helper::c_utf8_to_string(c_output_file_name,
-                                                    c_output_file_name_len));
+        let op_file = try!(helper::c_utf8_to_string(c_output_file_name, c_output_file_name_len));
         let fh = try!(FileHandler::<()>::new(&op_file, true)
-                                  .map_err(|e| CoreError::Unexpected(format!("{:?}", e))));
+            .map_err(|e| CoreError::Unexpected(format!("{:?}", e))));
         let op_file_path = try!(fh.path()
-                             .to_path_buf()
-                             .into_os_string()
-                             .into_string()
-                             .map_err(|e| CoreError::Unexpected(format!("{:?}", e))))
+                .to_path_buf()
+                .into_os_string()
+                .into_string()
+                .map_err(|e| CoreError::Unexpected(format!("{:?}", e))))
             .into_bytes();
 
         let ptr = op_file_path.as_ptr();

--- a/src/ffi/low_level_api/appendable_data.rs
+++ b/src/ffi/low_level_api/appendable_data.rs
@@ -26,12 +26,12 @@ use ffi::callback::CallbackArgs;
 use ffi::helper::catch_unwind_cb;
 use ffi::object_cache::ObjectCache;
 use futures::{self, Future};
-use libc::{c_void, int32_t, size_t, uint64_t};
 use routing::{AppendWrapper, AppendedData, Data, Filter, PrivAppendableData, PrivAppendedData,
               PubAppendableData, XOR_NAME_LEN, XorName};
 use std::collections::BTreeSet;
 use std::iter;
 use std::mem;
+use std::os::raw::c_void;
 
 type ADHandle = AppendableDataHandle;
 
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn appendable_data_new_pub(session: *const Session,
                                                  name: *const [u8; XOR_NAME_LEN],
                                                  user_data: *mut c_void,
                                                  o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                            int32_t,
+                                                                            i32,
                                                                             ADHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         let name = XorName(*name);
@@ -125,7 +125,7 @@ pub unsafe extern "C" fn appendable_data_new_priv(session: *const Session,
                                                   name: *const [u8; XOR_NAME_LEN],
                                                   user_data: *mut c_void,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                             int32_t,
+                                                                             i32,
                                                                              ADHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn appendable_data_get(session: *const Session,
                                              data_id_h: DataIdHandle,
                                              user_data: *mut c_void,
                                              o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                        int32_t,
+                                                                        i32,
                                                                         ADHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn appendable_data_extract_data_id(session: *const Session
                                                          ad_h: ADHandle,
                                                          user_data: *mut c_void,
                                                          o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                    int32_t,
+                                                                                    i32,
                                                                                     DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -241,7 +241,7 @@ fn appendable_data_extract_data_id_impl(object_cache: &ObjectCache,
 pub unsafe extern "C" fn appendable_data_put(session: *const Session,
                                              ad_h: ADHandle,
                                              user_data: *mut c_void,
-                                             o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                             o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn appendable_data_post(session: *const Session,
                                               ad_h: ADHandle,
                                               include_data: bool,
                                               user_data: *mut c_void,
-                                              o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                              o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -343,7 +343,7 @@ pub unsafe extern "C" fn appendable_data_filter_type(session: *const Session,
                                                      ad_h: ADHandle,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
+                                                                                i32,
                                                                                 FilterType)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn appendable_data_toggle_filter(session: *const Session,
                                                        ad_h: ADHandle,
                                                        user_data: *mut c_void,
                                                        o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                  int32_t)) {
+                                                                                  i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn appendable_data_insert_to_filter(session: *const Sessio
                                                           sign_key_h: SignKeyHandle,
                                                           user_data: *mut c_void,
                                                           o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                     int32_t)) {
+                                                                                     i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -434,7 +434,7 @@ pub unsafe extern "C" fn appendable_data_remove_from_filter(session: *const Sess
                                                             user_data: *mut c_void,
                                                             o_cb: unsafe extern "C"
                                                             fn(*mut c_void,
-                                                               int32_t)) {
+                                                               i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -465,7 +465,7 @@ pub unsafe extern "C" fn appendable_data_encrypt_key(session: *const Session,
                                                      ad_h: ADHandle,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
+                                                                                i32,
                                                                                 EncryptKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -496,8 +496,8 @@ pub unsafe extern "C" fn appendable_data_num_of_data(session: *const Session,
                                                      ad_h: ADHandle,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
-                                                                                size_t)) {
+                                                                                i32,
+                                                                                usize)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -517,8 +517,8 @@ pub unsafe extern "C" fn appendable_data_num_of_deleted_data(session: *const Ses
                                                              ad_h: ADHandle,
                                                              user_data: *mut c_void,
                                                              o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                        int32_t,
-                                                                                        size_t)) {
+                                                                                        i32,
+                                                                                        usize)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -563,7 +563,7 @@ pub unsafe extern "C" fn appendable_data_nth_data_id(session: *const Session,
                                                      n: usize,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
+                                                                                i32,
                                                                                 DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -587,7 +587,7 @@ pub unsafe extern "C" fn appendable_data_nth_deleted_data_id(session: *const Ses
                                                              user_data: *mut c_void,
                                                              o_cb: unsafe extern "C"
                                                              fn(*mut c_void,
-                                                                int32_t,
+                                                                i32,
                                                                 DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -645,7 +645,7 @@ pub unsafe extern "C" fn appendable_data_nth_data_sign_key(session: *const Sessi
                                                            user_data: *mut c_void,
                                                            o_cb: unsafe extern "C"
                                                            fn(*mut c_void,
-                                                              int32_t,
+                                                              i32,
                                                               SignKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -669,7 +669,7 @@ pub unsafe extern "C" fn appendable_data_nth_deleted_data_sign_key(session: *con
                                                                    user_data: *mut c_void,
                                                                    o_cb: unsafe extern "C"
                                                                    fn(*mut c_void,
-                                                                      int32_t,
+                                                                      i32,
                                                                       SignKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -723,7 +723,7 @@ pub unsafe extern "C" fn appendable_data_remove_nth_data(session: *const Session
                                                          n: usize,
                                                          user_data: *mut c_void,
                                                          o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                    int32_t)) {
+                                                                                    i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -767,7 +767,7 @@ pub unsafe extern "C" fn appendable_data_restore_nth_deleted_data(session: *cons
                                                                   user_data: *mut c_void,
                                                                   o_cb: unsafe extern "C"
                                                                   fn(*mut c_void,
-                                                                     int32_t)) {
+                                                                     i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -807,8 +807,7 @@ fn appendable_data_restore_nth_deleted_data_impl(obj_cache: &ObjectCache,
 pub unsafe extern "C" fn appendable_data_clear_data(session: *const Session,
                                                     ad_h: ADHandle,
                                                     user_data: *mut c_void,
-                                                    o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                               int32_t)) {
+                                                    o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -844,7 +843,7 @@ pub unsafe extern "C" fn appendable_data_remove_nth_deleted_data(session: *const
                                                                  user_data: *mut c_void,
                                                                  o_cb: unsafe extern "C"
                                                                  fn(*mut c_void,
-                                                                    int32_t)) {
+                                                                    i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -880,7 +879,7 @@ pub unsafe extern "C" fn appendable_data_clear_deleted_data(session: *const Sess
                                                             user_data: *mut c_void,
                                                             o_cb: unsafe extern "C"
                                                             fn(*mut c_void,
-                                                               int32_t)) {
+                                                               i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -908,7 +907,7 @@ pub unsafe extern "C" fn appendable_data_append(session: *const Session,
                                                 ad_h: ADHandle,
                                                 data_id_h: DataIdHandle,
                                                 user_data: *mut c_void,
-                                                o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                                o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -964,8 +963,8 @@ pub unsafe extern "C" fn appendable_data_version(session: *const Session,
                                                  handle: ADHandle,
                                                  user_data: *mut c_void,
                                                  o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                            int32_t,
-                                                                            uint64_t)) {
+                                                                            i32,
+                                                                            u64)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -992,7 +991,7 @@ pub unsafe extern "C" fn appendable_data_is_owned(session: *const Session,
                                                   handle: ADHandle,
                                                   user_data: *mut c_void,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                             int32_t,
+                                                                             i32,
                                                                              bool)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -1024,7 +1023,7 @@ pub unsafe extern "C" fn appendable_data_validate_size(session: *const Session,
                                                        handle: ADHandle,
                                                        user_data: *mut c_void,
                                                        o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                  int32_t,
+                                                                                  i32,
                                                                                   bool)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -1053,7 +1052,7 @@ fn appendable_data_validate_size_impl(obj_cache: &ObjectCache,
 pub unsafe extern "C" fn appendable_data_free(session: *const Session,
                                               handle: ADHandle,
                                               user_data: *mut c_void,
-                                              o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                              o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -1078,12 +1077,12 @@ mod tests {
     use ffi::{AppHandle, AppendableDataHandle, DataIdHandle, ObjectHandle};
     use ffi::{FfiError, Session, test_utils};
     use ffi::low_level_api::misc::*;
-    use libc::c_void;
     use rand;
     use routing::DataIdentifier;
     use rust_sodium::crypto::sign;
     use std::{panic, process};
     use std::collections::HashSet;
+    use std::os::raw::c_void;
     use std::sync::mpsc;
     use super::*;
 

--- a/src/ffi/low_level_api/cipher_opt.rs
+++ b/src/ffi/low_level_api/cipher_opt.rs
@@ -21,9 +21,9 @@
 
 use core::CoreError;
 use ffi::{App, CipherOptHandle, EncryptKeyHandle, FfiError, OpaqueCtx, Session, helper};
-use libc::{c_void, int32_t};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use rust_sodium::crypto::{box_, sealedbox, secretbox};
+use std::os::raw::c_void;
 
 /// Cipher Options
 #[derive(Debug)]
@@ -99,7 +99,7 @@ impl CipherOpt {
 pub unsafe extern "C" fn cipher_opt_new_plaintext(session: *const Session,
                                                   user_data: *mut c_void,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                             int32_t,
+                                                                             i32,
                                                                              CipherOptHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn cipher_opt_new_plaintext(session: *const Session,
 pub unsafe extern "C" fn cipher_opt_new_symmetric(session: *const Session,
                                                   user_data: *mut c_void,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                             int32_t,
+                                                                             i32,
                                                                              CipherOptHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
@@ -135,7 +135,7 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(session: *const Session,
                                                    peer_encrypt_key_h: EncryptKeyHandle,
                                                    user_data: *mut c_void,
                                                    o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                              int32_t,
+                                                                              i32,
                                                                               CipherOptHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(session: *const Session,
 pub unsafe extern "C" fn cipher_opt_free(session: *const Session,
                                          handle: CipherOptHandle,
                                          user_data: *mut c_void,
-                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -178,8 +178,8 @@ mod tests {
     use core::utility;
     use ffi::{App, CipherOptHandle, FfiError, Session};
     use ffi::test_utils;
-    use libc::c_void;
     use rust_sodium::crypto::box_;
+    use std::os::raw::c_void;
     use std::sync::mpsc;
     use super::*;
 

--- a/src/ffi/low_level_api/data_id.rs
+++ b/src/ffi/low_level_api/data_id.rs
@@ -20,8 +20,8 @@
 // and limitations relating to use of the SAFE Network Software.
 
 use ffi::{DataIdHandle, OpaqueCtx, Session, helper};
-use libc::{c_void, int32_t};
 use routing::{DataIdentifier, XOR_NAME_LEN, XorName};
+use std::os::raw::c_void;
 
 /// Construct DataIdentifier for StructuredData.
 #[no_mangle]
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn data_id_new_struct_data(session: *const Session,
                                                  id: *const [u8; XOR_NAME_LEN],
                                                  user_data: *mut c_void,
                                                  o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                            int32_t,
+                                                                            i32,
                                                                             DataIdHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let xor_id = XorName(*id);
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn data_id_new_immut_data(session: *const Session,
                                                 id: *const [u8; XOR_NAME_LEN],
                                                 user_data: *mut c_void,
                                                 o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                           int32_t,
+                                                                           i32,
                                                                            DataIdHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let xor_id = XorName(*id);
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn data_id_new_appendable_data(session: *const Session,
                                                      is_private: bool,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
+                                                                                i32,
                                                                                 DataIdHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let xor_id = XorName(*id);
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn data_id_new_appendable_data(session: *const Session,
 pub unsafe extern "C" fn data_id_free(session: *const Session,
                                       handle: DataIdHandle,
                                       user_data: *mut c_void,
-                                      o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                      o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -113,9 +113,9 @@ pub unsafe extern "C" fn data_id_free(session: *const Session,
 #[cfg(test)]
 mod tests {
     use ffi::{DataIdHandle, FfiError, Session, test_utils};
-    use libc::c_void;
     use rand;
     use routing::XOR_NAME_LEN;
+    use std::os::raw::c_void;
     use std::sync::mpsc;
     use super::*;
 
@@ -148,18 +148,10 @@ mod tests {
             data_id_new_immut_data(sess_ptr, &immut_id_arr, tx, data_id_cb);
             data_id_handle_immut = unwrap!(rx.recv());
 
-            data_id_new_appendable_data(sess_ptr,
-                                        &priv_app_id_arr,
-                                        true,
-                                        tx,
-                                        data_id_cb);
+            data_id_new_appendable_data(sess_ptr, &priv_app_id_arr, true, tx, data_id_cb);
             data_id_handle_priv_appendable = unwrap!(rx.recv());
 
-            data_id_new_appendable_data(sess_ptr,
-                                        &pub_app_id_arr,
-                                        false,
-                                        tx,
-                                        data_id_cb);
+            data_id_new_appendable_data(sess_ptr, &pub_app_id_arr, false, tx, data_id_cb);
             data_id_handle_pub_appendable = unwrap!(rx.recv());
         }
 

--- a/src/ffi/low_level_api/immut_data.rs
+++ b/src/ffi/low_level_api/immut_data.rs
@@ -26,11 +26,11 @@ use ffi::{FfiError, OpaqueCtx, Session};
 use ffi::helper::catch_unwind_cb;
 use ffi::low_level_api::cipher_opt::CipherOpt;
 use futures::Future;
-use libc::{c_void, int32_t, size_t};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use routing::{Data, DataIdentifier, ImmutableData};
 use self_encryption::{DataMap, SelfEncryptor, SequentialEncryptor};
 use std::{mem, ptr, slice};
+use std::os::raw::c_void;
 
 type SEWriterHandle = SelfEncryptorWriterHandle;
 type SEReaderHandle = SelfEncryptorReaderHandle;
@@ -40,7 +40,7 @@ type SEReaderHandle = SelfEncryptorReaderHandle;
 pub unsafe extern "C" fn immut_data_new_self_encryptor(session: *const Session,
                                                        user_data: *mut c_void,
                                                        o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                  int32_t,
+                                                                                  i32,
                                                                                   SEWriterHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn immut_data_write_to_self_encryptor(session: *const Sess
                                                             size: usize,
                                                             user_data: *mut c_void,
                                                             o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                       int32_t)) {
+                                                                                       i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn immut_data_close_self_encryptor(session: *const Session
                                                          cipher_opt_h: CipherOptHandle,
                                                          user_data: *mut c_void,
                                                          o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                    int32_t,
+                                                                                    i32,
                                                                                     DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -179,7 +179,7 @@ pub unsafe extern "C" fn immut_data_fetch_self_encryptor(session: *const Session
                                                          user_data: *mut c_void,
                                                          o_cb: unsafe extern "C" fn(
                                                              *mut c_void,
-                                                             int32_t,
+                                                             i32,
                                                              SEReaderHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn immut_data_fetch_self_encryptor(session: *const Session
 pub unsafe extern "C" fn immut_data_size(session: *const Session,
                                          se_h: SEReaderHandle,
                                          user_data: *mut c_void,
-                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t, u64)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, i32, u64)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -274,10 +274,10 @@ pub unsafe extern "C" fn immut_data_read_from_self_encryptor(session: *const Ses
                                                              len: u64,
                                                              user_data: *mut c_void,
                                                              o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                        int32_t,
+                                                                                        i32,
                                                                                         *mut u8,
-                                                                                        size_t,
-                                                                                        size_t)) {
+                                                                                        usize,
+                                                                                        usize)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -324,7 +324,7 @@ pub unsafe extern "C" fn immut_data_self_encryptor_writer_free(session: *const S
                                                                user_data: *mut c_void,
                                                                o_cb: unsafe
                                                                extern "C" fn(*mut c_void,
-                                                                             int32_t)) {
+                                                                             i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -343,7 +343,7 @@ pub unsafe extern "C" fn immut_data_self_encryptor_reader_free(session: *const S
                                                                user_data: *mut c_void,
                                                                o_cb: unsafe
                                                                extern "C" fn(*mut c_void,
-                                                                             int32_t)) {
+                                                                             i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -362,8 +362,8 @@ mod tests {
     use ffi::errors::FfiError;
     use ffi::low_level_api::cipher_opt::*;
     use ffi::low_level_api::data_id::data_id_free;
-    use libc::c_void;
     use std::{panic, process};
+    use std::os::raw::c_void;
     use std::sync::mpsc;
     use super::*;
 

--- a/src/ffi/low_level_api/misc.rs
+++ b/src/ffi/low_level_api/misc.rs
@@ -23,9 +23,9 @@ use ffi::{AppendableDataHandle, DataIdHandle, EncryptKeyHandle, SignKeyHandle, S
 use ffi::{FfiError, FfiResult, OpaqueCtx, Session, helper};
 use ffi::low_level_api::appendable_data::AppendableData;
 use ffi::object_cache::ObjectCache;
-use libc::{c_void, int32_t, size_t, uint8_t};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use std::{mem, ptr, slice};
+use std::os::raw::c_void;
 
 type ADHandle = AppendableDataHandle;
 
@@ -34,7 +34,7 @@ type ADHandle = AppendableDataHandle;
 pub unsafe extern "C" fn misc_encrypt_key_free(session: *const Session,
                                                handle: EncryptKeyHandle,
                                                user_data: *mut c_void,
-                                               o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                               o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn misc_encrypt_key_free(session: *const Session,
 pub unsafe extern "C" fn misc_sign_key_free(session: *const Session,
                                             handle: SignKeyHandle,
                                             user_data: *mut c_void,
-                                            o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                            o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -69,10 +69,10 @@ pub unsafe extern "C" fn misc_serialise_sign_key(session: *const Session,
                                                  sign_key_h: SignKeyHandle,
                                                  user_data: *mut c_void,
                                                  o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                            int32_t,
-                                                                            *mut uint8_t,
-                                                                            size_t,
-                                                                            size_t)) {
+                                                                            i32,
+                                                                            *mut u8,
+                                                                            usize,
+                                                                            usize)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn misc_deserialise_sign_key(session: *const Session,
                                                    size: usize,
                                                    user_data: *mut c_void,
                                                    o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                              int32_t,
+                                                                              i32,
                                                                               SignKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn misc_deserialise_sign_key(session: *const Session,
 pub unsafe extern "C" fn misc_maid_sign_key(session: *const Session,
                                             user_data: *mut c_void,
                                             o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                       int32_t,
+                                                                       i32,
                                                                        SignKeyHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -160,10 +160,10 @@ pub unsafe extern "C" fn misc_serialise_data_id(session: *const Session,
                                                 data_id_h: DataIdHandle,
                                                 user_data: *mut c_void,
                                                 o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                           int32_t,
-                                                                           *mut uint8_t,
-                                                                           size_t,
-                                                                           size_t)) {
+                                                                           i32,
+                                                                           *mut u8,
+                                                                           usize,
+                                                                           usize)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn misc_deserialise_data_id(session: *const Session,
                                                   size: usize,
                                                   user_data: *mut c_void,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                             int32_t,
+                                                                             i32,
                                                                              DataIdHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -230,10 +230,10 @@ pub unsafe extern "C" fn misc_serialise_appendable_data(session: *const Session,
                                                         ad_h: ADHandle,
                                                         user_data: *mut c_void,
                                                         o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                   int32_t,
-                                                                                   *mut uint8_t,
-                                                                                   size_t,
-                                                                                   size_t)) {
+                                                                                   i32,
+                                                                                   *mut u8,
+                                                                                   usize,
+                                                                                   usize)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -269,7 +269,7 @@ pub unsafe extern "C" fn misc_deserialise_appendable_data(session: *const Sessio
                                                           size: usize,
                                                           user_data: *mut c_void,
                                                           o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                     int32_t,
+                                                                                     i32,
                                                                                      ADHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -304,10 +304,10 @@ pub unsafe extern "C" fn misc_serialise_struct_data(session: *const Session,
                                                     sd_h: StructDataHandle,
                                                     user_data: *mut c_void,
                                                     o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                               int32_t,
-                                                                               *mut uint8_t,
-                                                                               size_t,
-                                                                               size_t)) {
+                                                                               i32,
+                                                                               *mut u8,
+                                                                               usize,
+                                                                               usize)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {
@@ -342,7 +342,7 @@ pub unsafe extern "C" fn misc_deserialise_struct_data(session: *const Session,
                                                       user_data: *mut c_void,
                                                       o_cb: unsafe extern "C"
                                                       fn(*mut c_void,
-                                                         int32_t,
+                                                         i32,
                                                          StructDataHandle)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn misc_u8_ptr_free(ptr: *mut u8, size: usize, capacity: u
 #[no_mangle]
 pub unsafe extern "C" fn misc_object_cache_reset(session: *const Session,
                                                  user_data: *mut c_void,
-                                                 o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                                 o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     helper::catch_unwind_cb(user_data, o_cb, || {

--- a/src/ffi/low_level_api/struct_data/mod.rs
+++ b/src/ffi/low_level_api/struct_data/mod.rs
@@ -28,9 +28,9 @@ use core::structured_data::{self, unversioned, versioned};
 use ffi::{AppHandle, CipherOptHandle, DataIdHandle, StructDataHandle};
 use ffi::{FfiError, OpaqueCtx, Session, helper};
 use futures::{self, Future};
-use libc::{c_void, int32_t, uint64_t};
 use routing::{Data, StructuredData, XOR_NAME_LEN, XorName};
 use std::{ptr, slice};
+use std::os::raw::c_void;
 use super::cipher_opt::CipherOpt;
 
 /// Create new StructuredData
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn struct_data_new(session: *const Session,
                                          data_len: usize,
                                          user_data: *mut c_void,
                                          o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                    int32_t,
+                                                                    i32,
                                                                     StructDataHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let id = XorName(*id);
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn struct_data_fetch(session: *const Session,
                                            data_id_h: DataIdHandle,
                                            user_data: *mut c_void,
                                            o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                      int32_t,
+                                                                      i32,
                                                                       StructDataHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn struct_data_extract_data_id(session: *const Session,
                                                      sd_h: StructDataHandle,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
+                                                                                i32,
                                                                                 DataIdHandle)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn struct_data_update(session: *const Session,
                                             data: *const u8,
                                             data_len: usize,
                                             user_data: *mut c_void,
-                                            o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                            o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let data = slice::from_raw_parts(data, data_len);
         let user_data = OpaqueCtx(user_data);
@@ -254,7 +254,7 @@ pub unsafe extern "C" fn struct_data_extract_data(session: *const Session,
                                                   sd_h: StructDataHandle,
                                                   user_data: *mut c_void,
                                                   o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                             int32_t,
+                                                                             i32,
                                                                              *mut u8,
                                                                              usize,
                                                                              usize)) {
@@ -303,8 +303,8 @@ pub unsafe extern "C" fn struct_data_num_of_versions(session: *const Session,
                                                      sd_h: StructDataHandle,
                                                      user_data: *mut c_void,
                                                      o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                                int32_t,
-                                                                                uint64_t)) {
+                                                                                i32,
+                                                                                u64)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -324,10 +324,10 @@ pub unsafe extern "C" fn struct_data_num_of_versions(session: *const Session,
 pub unsafe extern "C" fn struct_data_nth_version(session: *const Session,
                                                  app_h: AppHandle,
                                                  sd_h: StructDataHandle,
-                                                 n: uint64_t,
+                                                 n: u64,
                                                  user_data: *mut c_void,
                                                  o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                            int32_t,
+                                                                            i32,
                                                                             *mut u8,
                                                                             usize,
                                                                             usize)) {
@@ -371,9 +371,7 @@ pub unsafe extern "C" fn struct_data_nth_version(session: *const Session,
 pub unsafe extern "C" fn struct_data_version(session: *const Session,
                                              handle: StructDataHandle,
                                              user_data: *mut c_void,
-                                             o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                        int32_t,
-                                                                        uint64_t)) {
+                                             o_cb: unsafe extern "C" fn(*mut c_void, i32, u64)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -390,7 +388,7 @@ pub unsafe extern "C" fn struct_data_version(session: *const Session,
 pub unsafe extern "C" fn struct_data_put(session: *const Session,
                                          sd_h: StructDataHandle,
                                          user_data: *mut c_void,
-                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -430,7 +428,7 @@ pub unsafe extern "C" fn struct_data_put(session: *const Session,
 pub unsafe extern "C" fn struct_data_post(session: *const Session,
                                           sd_h: StructDataHandle,
                                           user_data: *mut c_void,
-                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                          o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -454,7 +452,7 @@ pub unsafe extern "C" fn struct_data_post(session: *const Session,
 pub unsafe extern "C" fn struct_data_delete(session: *const Session,
                                             sd_h: StructDataHandle,
                                             user_data: *mut c_void,
-                                            o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                            o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -479,9 +477,7 @@ pub unsafe extern "C" fn struct_data_delete(session: *const Session,
 pub unsafe extern "C" fn struct_data_validate_size(session: *const Session,
                                                    handle: StructDataHandle,
                                                    user_data: *mut c_void,
-                                                   o_cb: extern "C" fn(*mut c_void,
-                                                                       int32_t,
-                                                                       bool)) {
+                                                   o_cb: extern "C" fn(*mut c_void, i32, bool)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -498,9 +494,7 @@ pub unsafe extern "C" fn struct_data_validate_size(session: *const Session,
 pub unsafe extern "C" fn struct_data_is_owned(session: *const Session,
                                               sd_h: StructDataHandle,
                                               user_data: *mut c_void,
-                                              o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                         int32_t,
-                                                                         bool)) {
+                                              o_cb: unsafe extern "C" fn(*mut c_void, i32, bool)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -519,7 +513,7 @@ pub unsafe extern "C" fn struct_data_is_owned(session: *const Session,
 pub unsafe extern "C" fn struct_data_free(session: *const Session,
                                           handle: StructDataHandle,
                                           user_data: *mut c_void,
-                                          o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                          o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -70,7 +70,7 @@ pub use ffi::errors::FfiError;
 pub use ffi::session::Session;
 
 use futures::Future;
-use libc::c_void;
+use std::os::raw::c_void;
 
 /// Helper type to represent the FFI future result
 pub type FfiFuture<T> = Future<Item = T, Error = FfiError>;
@@ -82,7 +82,7 @@ unsafe impl Send for OpaqueCtx {}
 
 impl Into<*mut c_void> for OpaqueCtx {
     fn into(self) -> *mut c_void {
-       self.0
+        self.0
     }
 }
 

--- a/src/ffi/nfs/dir.rs
+++ b/src/ffi/nfs/dir.rs
@@ -26,10 +26,10 @@ use core::futures::FutureExt;
 use ffi::{App, AppHandle, FfiError, FfiFuture, OpaqueCtx, Session, helper};
 use ffi::dir_details::DirDetails;
 use futures::Future;
-use libc::{c_void, int32_t};
 use nfs::helper::dir_helper;
 use rust_sodium::crypto::secretbox;
 use std::{ptr, slice};
+use std::os::raw::c_void;
 use time;
 
 /// Create a new directory.
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn nfs_create_dir(session: *const Session,
                                         is_private: bool,
                                         is_shared: bool,
                                         user_data: *mut c_void,
-                                        o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                        o_cb: extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI create directory, given the path.");
 
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn nfs_delete_dir(session: *const Session,
                                         dir_path_len: usize,
                                         is_shared: bool,
                                         user_data: *mut c_void,
-                                        o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                        o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI delete dir, given the path.");
         let dir_path = try!(helper::c_utf8_to_str(dir_path, dir_path_len));
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn nfs_get_dir(session: *const Session,
                                      is_shared: bool,
                                      user_data: *mut c_void,
                                      o_cb: extern "C" fn(*mut c_void,
-                                                         int32_t,
+                                                         i32,
                                                          details_handle: *mut DirDetails)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get dir, given the path.");
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn nfs_modify_dir(session: *const Session,
                                         new_user_metadata: *const u8,
                                         new_user_metadata_len: usize,
                                         user_data: *mut c_void,
-                                        o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                        o_cb: extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI modify directory, given the path.");
         let dir_path = try!(helper::c_utf8_to_str(dir_path, dir_path_len));
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn nfs_move_dir(session: *const Session,
                                       is_dst_path_shared: bool,
                                       retain_src: bool,
                                       user_data: *mut c_void,
-                                      o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                      o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI move directory, from {:?} to {:?}.", src_path, dst_path);
 

--- a/src/ffi/nfs/file.rs
+++ b/src/ffi/nfs/file.rs
@@ -26,10 +26,10 @@ use ffi::{App, AppHandle, FfiError, FfiFuture, OpaqueCtx, Session, helper};
 use ffi::file_details::{FileDetails, FileMetadata};
 use ffi::helper::catch_unwind_cb;
 use futures::{self, Future};
-use libc::{c_void, int32_t, uint64_t};
 use nfs::{File, NfsError};
 use nfs::helper::{dir_helper, file_helper};
 use nfs::helper::writer::Mode;
+use std::os::raw::c_void;
 use std::ptr;
 use time;
 
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn nfs_delete_file(session: *const Session,
                                          file_path_len: usize,
                                          is_shared: bool,
                                          user_data: *mut c_void,
-                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn nfs_get_file(session: *const Session,
                                       include_metadata: bool,
                                       user_data: *mut c_void,
                                       o_cb: unsafe extern "C" fn(*mut c_void,
-                                                                 int32_t,
+                                                                 i32,
                                                                  *mut FileDetails)) {
     let user_data = OpaqueCtx(user_data);
 
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn nfs_modify_file(session: *const Session,
                                          new_content: *const u8,
                                          new_content_len: usize,
                                          user_data: *mut c_void,
-                                         o_cb: unsafe extern "C" fn(*mut c_void, int32_t)) {
+                                         o_cb: unsafe extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn nfs_move_file(session: *const Session,
                                        is_dst_path_shared: bool,
                                        retain_src: bool,
                                        user_data: *mut c_void,
-                                       o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                       o_cb: extern "C" fn(*mut c_void, i32)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -225,9 +225,7 @@ pub unsafe extern "C" fn nfs_get_file_num_of_versions(session: *const Session,
                                                       file_path_len: usize,
                                                       is_path_shared: bool,
                                                       user_data: *mut c_void,
-                                                      o_cb: extern "C" fn(*mut c_void,
-                                                                          int32_t,
-                                                                          uint64_t)) {
+                                                      o_cb: extern "C" fn(*mut c_void, i32, u64)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -280,7 +278,7 @@ pub unsafe extern "C" fn nfs_get_file_metadata(session: *const Session,
                                                version: u64,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void,
-                                                                   int32_t,
+                                                                   i32,
                                                                    *mut FileMetadata)) {
     let user_data = OpaqueCtx(user_data);
     catch_unwind_cb(user_data, o_cb, || {

--- a/src/ffi/nfs/file_writing.rs
+++ b/src/ffi/nfs/file_writing.rs
@@ -28,11 +28,11 @@
 use core::{Client, FutureExt, SelfEncryptionStorage};
 use ffi::{App, AppHandle, FfiError, FfiFuture, OpaqueCtx, Session, helper};
 use futures::Future;
-use libc::{c_void, int32_t};
 use nfs::helper::file_helper;
 use nfs::helper::writer::Mode;
 use nfs::helper::writer::Writer as InnerWriter;
 use std::{ptr, slice};
+use std::os::raw::c_void;
 
 /// File writer.
 pub struct Writer {
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn nfs_create_file(session: *const Session,
                                          is_path_shared: bool,
                                          is_versioned: bool,
                                          user_data: *mut c_void,
-                                         o_cb: extern "C" fn(*mut c_void, int32_t, *mut Writer)) {
+                                         o_cb: extern "C" fn(*mut c_void, i32, *mut Writer)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get nfs writer for creating a new file.");
 
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn nfs_writer_open(session: *const Session,
                                          file_path_len: usize,
                                          is_path_shared: bool,
                                          user_data: *mut c_void,
-                                         o_cb: extern "C" fn(*mut c_void, int32_t, *mut Writer)) {
+                                         o_cb: extern "C" fn(*mut c_void, i32, *mut Writer)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI get nfs writer for modification of existing file.");
         let file_path = try!(helper::c_utf8_to_str(file_path, file_path_len));
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn nfs_writer_write(session: *const Session,
                                           data: *const u8,
                                           len: usize,
                                           user_data: *mut c_void,
-                                          o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                          o_cb: extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI Write data using nfs writer.");
 
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn nfs_writer_write(session: *const Session,
 pub unsafe extern "C" fn nfs_writer_close(session: *const Session,
                                           writer_handle: *mut Writer,
                                           user_data: *mut c_void,
-                                          o_cb: extern "C" fn(*mut c_void, int32_t)) {
+                                          o_cb: extern "C" fn(*mut c_void, i32)) {
     helper::catch_unwind_cb(user_data, o_cb, || {
         trace!("FFI Close and consume nfs writer.");
 

--- a/src/ffi/string_list.rs
+++ b/src/ffi/string_list.rs
@@ -23,8 +23,8 @@
 //! corresponding FFI-enabled API.
 
 use ffi::errors::FfiError;
-use libc::c_char;
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::ptr;
 
 /// List of strings.
@@ -48,9 +48,8 @@ pub unsafe fn into_vec(list: *mut StringList) -> Result<Vec<String>, FfiError> {
     let mut result = Vec::with_capacity(cstrings.len());
 
     for cstring in cstrings {
-        result.push(try!(cstring.into_string().map_err(|err| {
-            FfiError::Unexpected(format!("{:?}", err))
-        })));
+        result.push(try!(cstring.into_string()
+            .map_err(|err| FfiError::Unexpected(format!("{:?}", err)))));
     }
 
     Ok(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ extern crate futures;
 #[cfg(feature = "use-mock-routing")]
 #[macro_use]
 extern crate lazy_static;
-extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate lru_cache;

--- a/tests/email_stress.rs
+++ b/tests/email_stress.rs
@@ -45,11 +45,9 @@ extern crate log;
 extern crate unwrap;
 
 extern crate crossbeam;
-extern crate libc;
 extern crate rust_sodium;
 extern crate safe_core;
 
-use libc::c_void;
 use rust_sodium::crypto::hash::sha256::{self, Digest};
 use safe_core::core::utility;
 use safe_core::ffi::{AppHandle, AppendableDataHandle, CipherOptHandle};
@@ -61,6 +59,7 @@ use safe_core::ffi::low_level_api::data_id::*;
 use safe_core::ffi::low_level_api::immut_data::*;
 use safe_core::ffi::low_level_api::misc::*;
 use safe_core::ffi::session::*;
+use std::os::raw::c_void;
 use std::ptr;
 use std::sync::Mutex;
 use std::sync::mpsc::{self, Sender};


### PR DESCRIPTION
libc dependency can be replaced with `std::os::raw::*`