### PR TITLE
refactor/ipc: remove manual impl of RustCEncodable for IpcResp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = "~0.3.14"
 # routing = "~0.27.1"
 routing = { git = "https://github.com/maidsafe/routing.git", branch = "mutable-data" }
 rust_sodium = "~0.1.2"
-rustc-serialize = "~0.3.19"
+rustc-serialize = "~0.3.22"
 self_encryption = { git = "https://github.com/maidsafe/self_encryption.git", branch = "dev" }
 time = "~0.1.35"
 tokio-core = "~0.1.1"


### PR DESCRIPTION
New version of rustc-serialise was released with builtin impl for
Result.