### PR TITLE
feat/authenticator: add API to get all registered apps

### DIFF
--- a/src/app/ffi/ipc.rs
+++ b/src/app/ffi/ipc.rs
@@ -127,11 +127,12 @@ pub unsafe extern "C" fn decode_ipc_msg(msg: FfiString,
 mod tests {
     use core::utility;
     use ipc::{self, AccessContInfo, AppExchangeInfo, AppKeys, AuthGranted, AuthReq, Config,
-              ContainerPermissions, ContainersReq, IpcMsg, IpcReq, IpcResp};
+              ContainersReq, IpcMsg, IpcReq, IpcResp};
     use ipc::req::ffi::Permission;
     use ipc::resp::ffi::AuthGranted as FfiAuthGranted;
     use rand;
     use rust_sodium::crypto::{box_, secretbox, sign};
+    use std::collections::HashMap;
     use std::mem;
     use std::os::raw::c_void;
     use super::*;
@@ -143,7 +144,7 @@ mod tests {
         let req = AuthReq {
             app: gen_app_exchange_info(),
             app_container: false,
-            containers: Vec::new(),
+            containers: HashMap::new(),
         };
 
         let req_c = req.clone().into_repr_c();
@@ -175,14 +176,13 @@ mod tests {
 
     #[test]
     fn encode_containers_req_basics() {
-        let container_permissions = ContainerPermissions {
-            container_key: unwrap!(utility::generate_random_string(10)),
-            access: btree_set![Permission::Read],
-        };
+        let mut container_permissions = HashMap::new();
+        let _ = container_permissions.insert(unwrap!(utility::generate_random_string(10)),
+                                             btree_set![Permission::Read]);
 
         let req = ContainersReq {
             app: gen_app_exchange_info(),
-            containers: vec![container_permissions],
+            containers: container_permissions,
         };
 
         let req_c = req.clone().into_repr_c();

--- a/src/app/ffi/nfs.rs
+++ b/src/app/ffi/nfs.rs
@@ -188,10 +188,11 @@ mod tests {
     use app::object_cache::CipherOptHandle;
     use app::test_util::{create_app_with_access, run_now};
     use core::{DIR_TAG, MDataInfo};
-    use ipc::{ContainerPermissions, Permission};
+    use ipc::Permission;
     use nfs::File as NativeFile;
     use nfs::NfsError;
     use routing::{XOR_NAME_LEN, XorName};
+    use std::collections::HashMap;
     use super::*;
     use util::ffi::{ErrorCode, FfiString};
     use util::ffi::test_util::{call_0, call_1, call_2, call_3};
@@ -200,16 +201,15 @@ mod tests {
     fn basics() {
         let container_info = unwrap!(MDataInfo::random_private(DIR_TAG));
 
-        let container_permissions = ContainerPermissions {
-            container_key: "_test".to_string(),
-            access: btree_set![Permission::Read,
-                               Permission::Insert,
-                               Permission::Update,
-                               Permission::Delete],
-        };
+        let mut container_permissions = HashMap::new();
+        let _ = container_permissions.insert("_test".to_string(),
+                                             (container_info.clone(),
+                                              btree_set![Permission::Read,
+                                                         Permission::Insert,
+                                                         Permission::Update,
+                                                         Permission::Delete]));
 
-        let app = create_app_with_access(vec![(container_info.clone(), container_permissions)],
-                                         true);
+        let app = create_app_with_access(container_permissions, true);
 
         let container_info_h = run_now(&app, move |_, context| {
             context.object_cache().insert_mdata_info(container_info)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -343,17 +343,17 @@ mod tests {
     fn get_container_mdata_info() {
         // Shared container
         let container_info = unwrap!(MDataInfo::random_private(DIR_TAG));
-        let container_key = "_test".to_string();
+        let cont_name = "_test".to_string();
 
         let mut container_permissions = HashMap::new();
-        let _ = container_permissions.insert(container_key.clone(),
+        let _ = container_permissions.insert(cont_name.clone(),
                                              (container_info.clone(),
                                               btree_set![Permission::Read]));
 
         let app = create_app_with_access(container_permissions, false);
 
         run(&app, move |client, context| {
-            context.get_container_mdata_info(client, container_key)
+            context.get_container_mdata_info(client, cont_name)
                 .then(move |res| {
                     let info = unwrap!(res);
                     assert_eq!(info, container_info);
@@ -367,23 +367,23 @@ mod tests {
     fn is_permitted() {
         // Shared container
         let container_info = unwrap!(MDataInfo::random_private(DIR_TAG));
-        let container_key = "_test".to_string();
+        let cont_name = "_test".to_string();
 
         let mut container_permissions = HashMap::new();
-        let _ = container_permissions.insert(container_key.clone(),
+        let _ = container_permissions.insert(cont_name.clone(),
                                              (container_info.clone(),
                                               btree_set![Permission::Read]));
 
         let app = create_app_with_access(container_permissions, false);
 
         run(&app, move |client, context| {
-            let f1 = context.is_permitted(client, container_key.clone(), Permission::Read)
+            let f1 = context.is_permitted(client, cont_name.clone(), Permission::Read)
                 .then(move |res| {
                     assert!(unwrap!(res));
                     Ok(())
                 });
 
-            let f2 = context.is_permitted(client, container_key.clone(), Permission::Insert)
+            let f2 = context.is_permitted(client, cont_name.clone(), Permission::Insert)
                 .then(move |res| {
                     assert!(!unwrap!(res));
                     Ok(())

--- a/src/app/test_util.rs
+++ b/src/app/test_util.rs
@@ -22,12 +22,13 @@
 use core::{Client, CoreFuture, FutureExt, MDataInfo, utility};
 use core::utility::test_utils::random_client;
 use futures::{Future, IntoFuture, future};
-use ipc::{AccessContInfo, AppKeys, AuthGranted, Config, ContainerPermissions};
+use ipc::{AccessContInfo, AppKeys, AuthGranted, Config, Permission};
 use maidsafe_utilities::serialisation::serialise;
 use rand;
 use routing::{Action, MutableData, PermissionSet, User, Value};
 use rust_sodium::crypto::{box_, secretbox, sign};
 use rust_sodium::crypto::hash::sha256;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::mpsc;
 use super::{App, AppContext};
 use super::errors::AppError;
@@ -123,7 +124,7 @@ pub fn create_unregistered_app() -> App {
 // Create app and grant it access to the specified containers.
 // If `create_containers` is true, also create all the containers specified in
 // the `access_info` and set their permissions accordingly.
-pub fn create_app_with_access(access_info: Vec<(MDataInfo, ContainerPermissions)>,
+pub fn create_app_with_access(access_info: HashMap<String, (MDataInfo, BTreeSet<Permission>)>,
                               create_containers: bool)
                               -> App {
     let app_id = unwrap!(utility::generate_random_string(10));
@@ -158,7 +159,7 @@ pub fn create_app_with_access(access_info: Vec<(MDataInfo, ContainerPermissions)
     let access_container_name = access_container_info.id;
     let access_container_type_tag = access_container_info.tag;
 
-    let container_infos: Vec<_> = access_info.into_iter().map(|(info, _)| info).collect();
+    let container_infos: Vec<_> = access_info.into_iter().map(|(_key, (info, _))| info).collect();
 
     // Put the access container on the network and authorise the app.
     let owner_key = random_client(move |client| {

--- a/src/authenticator/ffi/mod.rs
+++ b/src/authenticator/ffi/mod.rs
@@ -1,0 +1,176 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+use core::FutureExt;
+use core::utility::symmetric_decrypt;
+use futures::Future;
+use ipc::Permission;
+use maidsafe_utilities::serialisation::deserialise;
+use std::{mem, ptr};
+use std::os::raw::c_void;
+use super::{AccessContainerEntry, AuthError, Authenticator};
+use super::ipc::{access_container, access_container_key, get_config};
+use util::ffi::{FfiString, OpaqueCtx, catch_unwind_cb};
+use util::ffi::string::ffi_string_free;
+
+/// Application registered in the authenticator
+#[repr(C)]
+pub struct RegisteredApp {
+    /// Unique application identifier
+    pub app_id: FfiString,
+    /// List of containers that this application has access to
+    pub containers: *mut Container,
+    /// Length of containers vector
+    pub containers_len: usize,
+    /// Capacity of containers vector
+    pub containers_cap: usize,
+}
+
+/// Container and a list of permissions given to an app
+#[repr(C)]
+pub struct Container {
+    /// Name of the container
+    pub name: FfiString,
+    /// Vector of available permissions
+    pub permissions_ptr: *mut Permission,
+    /// Length of permissions vector
+    pub permissions_len: usize,
+    /// Capacity of permissions vector
+    pub permissions_cap: usize,
+}
+
+/// Get a list of apps registered in authenticator
+#[no_mangle]
+pub unsafe extern "C" fn authenticator_registered_apps(auth: *mut Authenticator,
+                                                       user_data: *mut c_void,
+                                                       o_cb: extern "C" fn(*mut c_void,
+                                                                           i32,
+                                                                           *mut RegisteredApp,
+                                                                           usize,
+                                                                           usize))
+                                                       -> i32 {
+    let user_data = OpaqueCtx(user_data);
+
+    catch_unwind_cb(user_data.0, o_cb, || -> Result<_, AuthError> {
+        (*auth).send(move |client| {
+                let c2 = client.clone();
+                let c3 = client.clone();
+
+                get_config(client.clone())
+                    .and_then(move |(_, auth_cfg)| {
+                        access_container(c2)
+                            .map(move |access_container| (access_container, auth_cfg))
+                    })
+                    .and_then(move |(access_container, auth_cfg)| {
+                        c3.list_mdata_entries(access_container.name, access_container.type_tag)
+                            .map_err(From::from)
+                            .map(move |entries| (access_container, entries, auth_cfg))
+                    })
+                    .and_then(move |(access_container, entries, auth_cfg)| {
+                        let mut apps = Vec::new();
+
+                        for app in auth_cfg.values() {
+                            let key =
+                                access_container_key(&access_container, &app.info.id, &app.keys)?;
+
+                            if let Some(entry) = entries.get(&key) {
+                                let plaintext = symmetric_decrypt(&entry.content,
+                                                                  &app.keys.enc_key)?;
+                                let app_access = deserialise::<AccessContainerEntry>(&plaintext)?;
+
+                                let mut containers = Vec::new();
+
+                                for (key, (_, perms)) in app_access {
+                                    let mut perms = perms.iter().cloned().collect::<Vec<_>>();
+                                    let ptr = perms.as_mut_ptr();
+                                    let len = perms.len();
+                                    let cap = perms.capacity();
+                                    mem::forget(perms);
+
+                                    containers.push(Container {
+                                        name: FfiString::from_string(key),
+                                        permissions_ptr: ptr,
+                                        permissions_len: len,
+                                        permissions_cap: cap,
+                                    });
+                                }
+
+                                let p = containers.as_mut_ptr();
+                                let len = containers.len();
+                                let cap = containers.capacity();
+                                mem::forget(containers);
+
+                                let reg_app = RegisteredApp {
+                                    app_id: FfiString::from_string(app.info.id.clone()),
+                                    containers: p,
+                                    containers_len: len,
+                                    containers_cap: cap,
+                                };
+
+                                apps.push(reg_app);
+                            }
+                        }
+
+                        let p = apps.as_mut_ptr();
+                        let len = apps.len();
+                        let cap = apps.capacity();
+                        mem::forget(apps);
+
+                        o_cb(user_data.0, 0, p, len, cap);
+                        Ok(())
+                    })
+                    .map_err(move |e| {
+                        o_cb(user_data.0, ffi_error_code!(e), ptr::null_mut(), 0, 0)
+                    })
+                    .into_box()
+                    .into()
+            })?;
+
+        Ok(())
+    });
+
+    0
+}
+
+/// Free memory allocated for a `RegisteredApp` structure
+#[no_mangle]
+pub unsafe extern "C" fn registered_app_free(app: *mut RegisteredApp) {
+    let app = Box::from_raw(app);
+    ffi_string_free(app.app_id);
+
+    let containers = Vec::from_raw_parts(app.containers, app.containers_len, app.containers_cap);
+
+    for cont in containers {
+        ffi_string_free(cont.name);
+
+        let _ = Vec::from_raw_parts(cont.permissions_ptr,
+                                    cont.permissions_len,
+                                    cont.permissions_cap);
+    }
+}
+
+/// Free memory allocated to a vector of registered applications
+#[no_mangle]
+pub unsafe extern "C" fn authenticator_registered_apps_free(apps: *mut RegisteredApp,
+                                                            len: usize,
+                                                            cap: usize) {
+    let _ = Vec::from_raw_parts(apps, len, cap);
+}

--- a/src/authenticator/mod.rs
+++ b/src/authenticator/mod.rs
@@ -21,21 +21,24 @@
 
 #![allow(unsafe_code)]
 
+/// FFI routines
+pub mod ffi;
 /// Authenticator communication with apps
 pub mod ipc;
 /// Authenticator errors
 mod errors;
 
-use core::{self, Client, CoreMsg, CoreMsgTx, FutureExt, NetworkEvent};
+use core::{self, Client, CoreMsg, CoreMsgTx, FutureExt, MDataInfo, NetworkEvent};
 use futures::Future;
 use futures::stream::Stream;
 use futures::sync::mpsc::{self, SendError};
+use ipc::Permission;
 use maidsafe_utilities::serialisation::serialise;
 use maidsafe_utilities::thread::{self, Joiner};
 use nfs::{create_dir, create_std_dirs};
 use routing::{EntryAction, Value};
 pub use self::errors::AuthError;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::os::raw::c_void;
 use std::sync::Mutex;
 use std::sync::mpsc::sync_channel;
@@ -44,6 +47,9 @@ use util::ffi::{FfiString, OpaqueCtx, catch_unwind_error_code};
 
 /// Future type specialised with `AuthError` as an error type
 pub type AuthFuture<T> = Future<Item = T, Error = AuthError>;
+
+/// Represents an entry for a single app in the access container
+pub type AccessContainerEntry = HashMap<String, (MDataInfo, BTreeSet<Permission>)>;
 
 macro_rules! try_tx {
     ($result:expr, $tx:ident) => {

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -28,7 +28,7 @@ mod errors;
 
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 pub use self::errors::IpcError;
-pub use self::req::{AppExchangeInfo, AuthReq, ContainerPermissions, ContainersReq, IpcReq};
+pub use self::req::{AppExchangeInfo, AuthReq, ContainersReq, IpcReq};
 pub use self::req::ffi::Permission;
 pub use self::resp::{AccessContInfo, AppKeys, AuthGranted, IpcResp};
 use util;

--- a/src/ipc/req/ffi.rs
+++ b/src/ipc/req/ffi.rs
@@ -20,7 +20,7 @@
 // and limitations relating to use of the SAFE Network Software.
 
 use std::mem;
-use util::ffi::FfiString;
+use util::ffi::{FfiString, string};
 
 /// Permission action
 #[repr(C)]
@@ -125,7 +125,8 @@ pub struct ContainerPermissions {
 #[no_mangle]
 #[allow(unsafe_code)]
 pub unsafe extern "C" fn container_permissions_drop(cp: ContainerPermissions) {
-    let _ = super::ContainerPermissions::from_repr_c(cp);
+    string::ffi_string_free(cp.container_key);
+    permission_array_free(cp.access);
 }
 
 /// Wrapper for `ContainerPermissions` arrays to be passed across FFI boundary.

--- a/src/ipc/req/ffi.rs
+++ b/src/ipc/req/ffi.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn app_exchange_info_drop(a: AppExchangeInfo) {
 #[derive(Clone, Copy)]
 pub struct ContainerPermissions {
     /// The UTF-8 encoded id
-    pub container_key: FfiString,
+    pub cont_name: FfiString,
 
     /// The `Permission` array
     pub access: PermissionArray,
@@ -125,7 +125,7 @@ pub struct ContainerPermissions {
 #[no_mangle]
 #[allow(unsafe_code)]
 pub unsafe extern "C" fn container_permissions_drop(cp: ContainerPermissions) {
-    string::ffi_string_free(cp.container_key);
+    string::ffi_string_free(cp.cont_name);
     permission_array_free(cp.access);
 }
 

--- a/src/ipc/req/mod.rs
+++ b/src/ipc/req/mod.rs
@@ -54,11 +54,11 @@ pub struct AuthReq {
 /// Converts a container name + a set of permissions into an FFI
 /// representation `ContainerPermissions`. You're now responsible for
 /// freeing this memory once you're done.
-pub fn container_perm_into_repr_c(container_key: String,
+pub fn container_perm_into_repr_c(cont_name: String,
                                   access: BTreeSet<Permission>)
                                   -> ffi::ContainerPermissions {
     ffi::ContainerPermissions {
-        container_key: FfiString::from_string(container_key),
+        cont_name: FfiString::from_string(cont_name),
         access: ffi::PermissionArray::from_vec(access.into_iter().collect()),
     }
 }
@@ -86,10 +86,10 @@ pub unsafe fn containers_from_repr_c(raw: ffi::ContainerPermissionsArray)
     let vec = raw.into_vec();
 
     for raw in vec {
-        let container_key = raw.container_key.to_string();
-        ffi_string_free(raw.container_key);
+        let cont_name = raw.cont_name.to_string();
+        ffi_string_free(raw.cont_name);
 
-        let _ = result.insert(container_key?, raw.access.into_vec().into_iter().collect());
+        let _ = result.insert(cont_name?, raw.access.into_vec().into_iter().collect());
     }
 
     Ok(result)

--- a/src/ipc/req/mod.rs
+++ b/src/ipc/req/mod.rs
@@ -24,7 +24,7 @@ pub mod ffi;
 
 use ipc::errors::IpcError;
 use self::ffi::Permission;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::mem;
 use util::ffi::FfiString;
 use util::ffi::string::ffi_string_free;
@@ -48,7 +48,51 @@ pub struct AuthReq {
     /// otherwise.
     pub app_container: bool,
     /// The list of containers it wishes to access (and desired permissions).
-    pub containers: Vec<ContainerPermissions>,
+    pub containers: HashMap<String, BTreeSet<Permission>>,
+}
+
+/// Converts a container name + a set of permissions into an FFI
+/// representation `ContainerPermissions`. You're now responsible for
+/// freeing this memory once you're done.
+pub fn container_perm_into_repr_c(container_key: String,
+                                  access: BTreeSet<Permission>)
+                                  -> ffi::ContainerPermissions {
+    ffi::ContainerPermissions {
+        container_key: FfiString::from_string(container_key),
+        access: ffi::PermissionArray::from_vec(access.into_iter().collect()),
+    }
+}
+
+/// Consumes the object and returns the wrapped raw pointer
+///
+/// You're now responsible for freeing this memory once you're done.
+pub fn containers_into_repr_c(containers: HashMap<String, BTreeSet<Permission>>)
+                              -> ffi::ContainerPermissionsArray {
+    let mut container_perms = Vec::new();
+    for (key, access) in containers {
+        container_perms.push(container_perm_into_repr_c(key, access));
+    }
+    ffi::ContainerPermissionsArray::from_vec(container_perms)
+}
+
+/// Constructs the object from a raw pointer.
+///
+/// After calling this function, the raw pointer is owned by the resulting
+/// object.
+#[allow(unsafe_code)]
+pub unsafe fn containers_from_repr_c(raw: ffi::ContainerPermissionsArray)
+                                     -> Result<HashMap<String, BTreeSet<Permission>>, IpcError> {
+    let mut result = HashMap::new();
+    let vec = raw.into_vec();
+
+    for raw in vec {
+        let container_key = raw.container_key.to_string();
+        ffi_string_free(raw.container_key);
+
+        let _ = result.insert(container_key?, raw.access.into_vec().into_iter().collect());
+    }
+
+    Ok(result)
 }
 
 impl AuthReq {
@@ -59,14 +103,12 @@ impl AuthReq {
     pub fn into_repr_c(self) -> ffi::AuthReq {
         let AuthReq { app, app_container, containers } = self;
 
-        let containers: Vec<_> = containers.into_iter()
-            .map(|c| c.into_repr_c())
-            .collect();
+        let containers = containers_into_repr_c(containers);
 
         ffi::AuthReq {
             app: app.into_repr_c(),
             app_container: app_container,
-            containers: ffi::ContainerPermissionsArray::from_vec(containers),
+            containers: containers,
         }
     }
 
@@ -77,20 +119,11 @@ impl AuthReq {
     #[allow(unsafe_code)]
     pub unsafe fn from_repr_c(repr_c: ffi::AuthReq) -> Result<Self, IpcError> {
         let ffi::AuthReq { app, app_container, containers } = repr_c;
-        let container_results = containers.into_vec()
-            .into_iter()
-            .map(|c| ContainerPermissions::from_repr_c(c));
-
-        let mut containers = Vec::new();
-
-        for result in container_results {
-            containers.push(result?);
-        }
 
         Ok(AuthReq {
             app: AppExchangeInfo::from_repr_c(app)?,
             app_container: app_container,
-            containers: containers,
+            containers: containers_from_repr_c(containers)?,
         })
     }
 }
@@ -101,7 +134,7 @@ pub struct ContainersReq {
     /// Exchange info
     pub app: AppExchangeInfo,
     /// Requested containers
-    pub containers: Vec<ContainerPermissions>,
+    pub containers: HashMap<String, BTreeSet<Permission>>,
 }
 
 impl ContainersReq {
@@ -111,13 +144,10 @@ impl ContainersReq {
     /// done.
     pub fn into_repr_c(self) -> ffi::ContainersReq {
         let ContainersReq { app, containers } = self;
-        let containers: Vec<_> = containers.into_iter()
-            .map(|c| c.into_repr_c())
-            .collect();
 
         ffi::ContainersReq {
             app: app.into_repr_c(),
-            containers: ffi::ContainerPermissionsArray::from_vec(containers),
+            containers: containers_into_repr_c(containers),
         }
     }
 
@@ -128,19 +158,9 @@ impl ContainersReq {
     #[allow(unsafe_code)]
     pub unsafe fn from_repr_c(repr_c: ffi::ContainersReq) -> Result<Self, IpcError> {
         let ffi::ContainersReq { app, containers } = repr_c;
-        let container_results = containers.into_vec()
-            .into_iter()
-            .map(|c| ContainerPermissions::from_repr_c(c));
-
-        let mut containers = Vec::new();
-
-        for result in container_results {
-            containers.push(result?);
-        }
-
         Ok(ContainersReq {
             app: AppExchangeInfo::from_repr_c(app)?,
-            containers: containers,
+            containers: containers_from_repr_c(containers)?,
         })
     }
 }
@@ -210,72 +230,29 @@ impl AppExchangeInfo {
     }
 }
 
-/// Represents the set of permissions for a given container
-#[derive(Clone, Eq, PartialEq, RustcEncodable, RustcDecodable, Debug)]
-pub struct ContainerPermissions {
-    /// The id
-    pub container_key: String,
-    /// The permissions
-    pub access: BTreeSet<Permission>,
-}
-
-impl ContainerPermissions {
-    /// Consumes the object and returns the wrapped raw pointer
-    ///
-    /// You're now responsible for freeing this memory once you're done.
-    pub fn into_repr_c(self) -> ffi::ContainerPermissions {
-        let ContainerPermissions { container_key, access } = self;
-
-        ffi::ContainerPermissions {
-            container_key: FfiString::from_string(container_key),
-            access: ffi::PermissionArray::from_vec(access.into_iter().collect()),
-        }
-    }
-
-    /// Constructs the object from a raw pointer.
-    ///
-    /// After calling this function, the raw pointer is owned by the resulting
-    /// object.
-    #[allow(unsafe_code)]
-    pub unsafe fn from_repr_c(raw: ffi::ContainerPermissions) -> Result<Self, IpcError> {
-        let container_key = raw.container_key.to_string();
-        ffi_string_free(raw.container_key);
-
-        Ok(ContainerPermissions {
-            container_key: container_key?,
-            access: raw.access.into_vec().into_iter().collect(),
-        })
-    }
-}
-
 #[cfg(test)]
 #[allow(unsafe_code)]
 mod tests {
+    use std::collections::HashMap;
     use super::*;
 
     #[test]
     fn container_permissions() {
-        let cp = ContainerPermissions {
-            container_key: "foobar".to_string(),
-            access: Default::default(),
-        };
+        let mut cp = HashMap::new();
+        let _ = cp.insert("foobar".to_string(), Default::default());
 
-        let ffi_cp = cp.into_repr_c();
+        let ffi_cp = containers_into_repr_c(cp);
+        assert_eq!(ffi_cp.len, 1);
 
-        unsafe {
-            assert_eq!(unwrap!(ffi_cp.container_key.as_str()), "foobar");
-            assert_eq!(ffi_cp.access.len, 0);
-        }
+        let cp = unsafe { unwrap!(containers_from_repr_c(ffi_cp)) };
 
-        let cp = unsafe { unwrap!(ContainerPermissions::from_repr_c(ffi_cp)) };
-
-        assert_eq!(cp.container_key, "foobar");
-        assert!(cp.access.is_empty());
+        assert!(cp.contains_key("foobar"));
+        assert!(unwrap!(cp.get("foobar")).is_empty());
 
         // If test runs under special mode (e.g. Valgrind) we can detect memory
         // leaks
         unsafe {
-            ffi::container_permissions_drop(cp.into_repr_c());
+            ffi::container_permissions_array_free(containers_into_repr_c(cp));
         }
     }
 
@@ -332,7 +309,7 @@ mod tests {
         let a = AuthReq {
             app: app,
             app_container: false,
-            containers: vec![],
+            containers: HashMap::new(),
         };
 
         let ffi = a.into_repr_c();
@@ -363,7 +340,7 @@ mod tests {
 
         let a = ContainersReq {
             app: app,
-            containers: vec![],
+            containers: HashMap::new(),
         };
 
         let ffi = a.into_repr_c();


### PR DESCRIPTION
Also contains changes to data types stored in the access container (replaced ContainerPermissions with BTreeSet<Permission>)